### PR TITLE
Remove options.configuration DiffSuppressFunc to consistently detect configuration changes.

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -1,8 +1,6 @@
 package auth0
 
 import (
-	"strings"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	auth0 "github.com/yieldr/go-auth0"
@@ -154,9 +152,6 @@ func newConnection() *schema.Resource {
 							Elem:      &schema.Schema{Type: schema.TypeString},
 							Sensitive: true,
 							Optional:  true,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return strings.HasPrefix(old, "2.0$") || new == old
-							},
 						},
 					},
 				},

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -26,7 +26,6 @@ func TestAccConnection(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.disable_signup", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.requires_username", "true"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.custom_scripts.get_user", "myFunction"),
-					resource.TestCheckResourceAttrSet("auth0_connection.my_connection", "options.0.configuration.foo"),
 				),
 			},
 		},
@@ -53,6 +52,37 @@ resource "auth0_connection" "my_connection" {
 		custom_scripts = {
 			get_user = "myFunction"
 		}
+	}
+}
+`
+
+func TestAccConnectionWithOptionsConfigurationChildDetectsChange(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccConnectionWithOptionsConfigurationChildConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection_with_options_configuration", "name", "Acc-Test-Conn-With-Options-Config"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection_with_options_configuration", "strategy", "auth0"),
+					resource.TestCheckResourceAttrSet("auth0_connection.my_connection_with_options_configuration", "options.0.configuration.foo"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+const testAccConnectionWithOptionsConfigurationChildConfig = `
+provider "auth0" {}
+
+resource "auth0_connection" "my_connection_with_options_configuration" {
+	name = "Acc-Test-Conn-With-Options-Config"
+	strategy = "auth0"
+	options = {
 		configuration = {
 			foo = "bar"
 		}


### PR DESCRIPTION
This pull request is a bit coarse, but I'd also love if it resulted in a more elegant solutions. Does anyone know what encryption algorithm gets used by Auth0 and whether we can accurately detect changes to the sensitive value?

With the previous `DiffSuppressFunc` in place, changes to `options.configuration` values would not be detected. Consider the following use case:
1. Set `foo=bar` configuration and perform `terraform apply`.
2. When the value for `foo=bar` is retrieved next from Auth0, it will be encrypted as "2.0$abc123"
3. set `foo=baz` and perform `terraform apply`. Because the current, encrypted value is "2.0$abc123" and `strings.HasPrefix(old, "2.0$")` returns true, no diff would be detected.

With the changes from this PR, the `old` encrypted value of "2.0$abc123" will always be different than the `new` plaintext value. So `terraform apply` will always detect a change. However, the remote Auth0 configuration is at least in a consistent state.