### PR TITLE
fixes example for password_history

### DIFF
--- a/example/connection/main.tf
+++ b/example/connection/main.tf
@@ -6,8 +6,8 @@ resource "auth0_connection" "my_connection" {
   options = {
     password_policy = "excellent"
     password_history = {
-      enable = true
-      size = 3
+      enable = "true"
+      size = "3"
     }
     brute_force_protection = "true"
     enabled_database_customization = "true"


### PR DESCRIPTION
Fixes password_history example to use quoted string properties versus boolean number. Related to #40.