### PR TITLE
docs: include GO111MODULE=on environment variable

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,6 +4,7 @@ FILES ?= $$(find . -name '*.go' | grep -v vendor)
 TESTS ?= ".*"
 COVERS ?= "c.out"
 WEBSITE_REPO = github.com/hashicorp/terraform-website
+export GO111MODULE=on
 
 default: build
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ mkdir -p $GOPATH/src/github.com/yieldr; cd $GOPATH/src/github.com/yieldr
 $ git clone git@github.com:yieldr/terraform-provider-auth0
 ```
 
-Enable Go 1.11 modules:
+Enable Go 1.11 modules
 
 ```sh
 $ export GO111MODULE=on

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ $ mkdir -p $GOPATH/src/github.com/yieldr; cd $GOPATH/src/github.com/yieldr
 $ git clone git@github.com:yieldr/terraform-provider-auth0
 ```
 
+Enable Go 1.11 modules:
+
+```sh
+$ export GO111MODULE=on
+```
+
 Enter the provider directory and build the provider
 
 ```sh


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Improves README for new Go users to enable Go 1.11 modules via `export GO111MODULE=on`

Output from acceptance testing:

N/A
