### PR TITLE
Use set instead of list for enabled clients

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -381,7 +381,7 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 		Name:               String(d, "name"),
 		IsDomainConnection: Bool(d, "is_domain_connection"),
 		Strategy:           String(d, "strategy"),
-		EnabledClients:     Set(d, "enabled_clients"),
+		EnabledClients:     Set(d, "enabled_clients").Slice(),
 		Realms:             Slice(d, "realms"),
 	}
 

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -268,22 +268,9 @@ func newConnection() *schema.Resource {
 				},
 			},
 			"enabled_clients": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if strings.Contains(k, "#") {
-						return old == new
-					}
-
-					enabledClients := Slice(d, "enabled_clients")
-					result := false
-					for _, v := range enabledClients {
-						result = result || (v == old)
-					}
-
-					return result
-				},
 			},
 			"realms": {
 				Type:     schema.TypeList,
@@ -394,7 +381,7 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 		Name:               String(d, "name"),
 		IsDomainConnection: Bool(d, "is_domain_connection"),
 		Strategy:           String(d, "strategy"),
-		EnabledClients:     Slice(d, "enabled_clients"),
+		EnabledClients:     Set(d, "enabled_clients").List(),
 		Realms:             Slice(d, "realms"),
 	}
 

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -381,7 +381,7 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 		Name:               String(d, "name"),
 		IsDomainConnection: Bool(d, "is_domain_connection"),
 		Strategy:           String(d, "strategy"),
-		EnabledClients:     Set(d, "enabled_clients").List(),
+		EnabledClients:     Set(d, "enabled_clients"),
 		Realms:             Slice(d, "realms"),
 	}
 

--- a/auth0/resource_data.go
+++ b/auth0/resource_data.go
@@ -92,20 +92,6 @@ func Slice(d Data, key string) (s []interface{}) {
 	return
 }
 
-// Set accesses the value held by key, type asserts it to a set and returns an
-// iterator able to go over the items of the list.
-func Set(d Data, key string) *iterator {
-	if d.HasChange(key) {
-		v, ok := d.GetOkExists(key)
-		if ok {
-			if s, ok := v.(*schema.Set); ok {
-				return &iterator{s.List()}
-			}
-		}
-	}
-	return &iterator{}
-}
-
 // Map accesses the value held by key and type asserts it to a map.
 func Map(d Data, key string) (m map[string]interface{}) {
 	if d.HasChange(key) {
@@ -127,6 +113,20 @@ func List(d Data, key string) *iterator {
 		v, ok := d.GetOkExists(key)
 		if ok {
 			return &iterator{v.([]interface{})}
+		}
+	}
+	return &iterator{}
+}
+
+// Set accesses the value held by key, type asserts it to a set and returns an
+// iterator able to go over the items of the list.
+func Set(d Data, key string) *iterator {
+	if d.HasChange(key) {
+		v, ok := d.GetOkExists(key)
+		if ok {
+			if s, ok := v.(*schema.Set); ok {
+				return &iterator{s.List()}
+			}
 		}
 	}
 	return &iterator{}

--- a/auth0/resource_data.go
+++ b/auth0/resource_data.go
@@ -92,12 +92,15 @@ func Slice(d Data, key string) (s []interface{}) {
 	return
 }
 
-// Set accesses the value held by key and type asserts it to a set.
-func Set(d Data, key string) (s *schema.Set) {
+// Set accesses the value held by key, type asserts it to a set and returns a
+// slice containing its values.
+func Set(d Data, key string) (s []interface{}) {
 	if d.HasChange(key) {
 		v, ok := d.GetOkExists(key)
 		if ok {
-			s = v.(*schema.Set)
+			if set, ok := v.(*schema.Set); ok {
+				s = set.List()
+			}
 		}
 	}
 	return

--- a/auth0/resource_data.go
+++ b/auth0/resource_data.go
@@ -92,18 +92,18 @@ func Slice(d Data, key string) (s []interface{}) {
 	return
 }
 
-// Set accesses the value held by key, type asserts it to a set and returns a
-// slice containing its values.
-func Set(d Data, key string) (s []interface{}) {
+// Set accesses the value held by key, type asserts it to a set and returns an
+// iterator able to go over the items of the list.
+func Set(d Data, key string) *iterator {
 	if d.HasChange(key) {
 		v, ok := d.GetOkExists(key)
 		if ok {
-			if set, ok := v.(*schema.Set); ok {
-				s = set.List()
+			if s, ok := v.(*schema.Set); ok {
+				return &iterator{s.List()}
 			}
 		}
 	}
-	return
+	return &iterator{}
 }
 
 // Map accesses the value held by key and type asserts it to a map.
@@ -152,4 +152,9 @@ func (i *iterator) First(f func(value interface{})) {
 		f(value)
 		return
 	}
+}
+
+// Slice returns the underlying list as a raw slice.
+func (i *iterator) Slice() []interface{} {
+	return i.i
 }

--- a/auth0/resource_data.go
+++ b/auth0/resource_data.go
@@ -92,6 +92,17 @@ func Slice(d Data, key string) (s []interface{}) {
 	return
 }
 
+// Set accesses the value held by key and type asserts it to a set.
+func Set(d Data, key string) (s *schema.Set) {
+	if d.HasChange(key) {
+		v, ok := d.GetOkExists(key)
+		if ok {
+			s = v.(*schema.Set)
+		}
+	}
+	return
+}
+
 // Map accesses the value held by key and type asserts it to a map.
 func Map(d Data, key string) (m map[string]interface{}) {
 	if d.HasChange(key) {


### PR DESCRIPTION
The `schema.Set` type is intended for unordered lists, so using it means
we don't need to define a `DiffSuppressFunc` to prevent differences from
appearing due to the ordering of the enabled clients.

The `DiffSuppressFunc` was causing incorrect behaviour when adding a new
enabled client to a connection so rather than fix the function using a
set seems simpler.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request
