### PR TITLE
fix incorrect schema for connection option password_no_personal_info

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -88,9 +88,17 @@ func newConnection() *schema.Resource {
 							},
 						},
 						"password_no_personal_info": {
-							Type:     schema.TypeMap,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enable": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
 						},
 						"password_dictionary": {
 							Type:     schema.TypeMap,
@@ -405,7 +413,6 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 		c.Options = &management.ConnectionOptions{
 			Validation:                   Map(MapData(m), "validation"),
 			PasswordPolicy:               String(MapData(m), "password_policy"),
-			PasswordNoPersonalInfo:       Map(MapData(m), "password_no_personal_info"),
 			PasswordDictionary:           Map(MapData(m), "password_dictionary"),
 			APIEnableUsers:               Bool(MapData(m), "api_enable_users"),
 			BasicProfile:                 Bool(MapData(m), "basic_profile"),
@@ -460,6 +467,14 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 			c.Options.PasswordHistory = make(map[string]interface{})
 			c.Options.PasswordHistory["enable"] = Bool(MapData(m), "enable")
 			c.Options.PasswordHistory["size"] = Int(MapData(m), "size")
+		})
+
+		List(MapData(m), "password_no_personal_info").First(func(v interface{}) {
+
+			m := v.(map[string]interface{})
+
+			c.Options.PasswordNoPersonalInfo = make(map[string]interface{})
+			c.Options.PasswordNoPersonalInfo["enable"] = Bool(MapData(m), "enable")
 		})
 	})
 

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -21,6 +21,7 @@ func TestAccConnection(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "is_domain_connection", "true"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "strategy", "auth0"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.password_policy", "fair"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.password_no_personal_info.0.enable", "true"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.enabled_database_customization", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.brute_force_protection", "true"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.import_mode", "true"),
@@ -46,6 +47,9 @@ resource "auth0_connection" "my_connection" {
 		password_history = {
 			enable = true
 			size = 5
+		}
+		password_no_personal_info = {
+			enable = true
 		}
 		enabled_database_customization = false
 		brute_force_protection = true


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* fix schema for connection option `password_no_personal_info` such that enabling/disabling personal data usage in passwords works as expected

Output from acceptance testing:

```
$ make testacc TESTS=TestAccConnection
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v  -timeout 120m -coverprofile="c.out" -run ^TestAccConnection$
?       github.com/alexkappa/terraform-provider-auth0   [no test files]
=== RUN   TestAccConnection
--- PASS: TestAccConnection (0.55s)
PASS
coverage: 18.1% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0     0.563s  coverage: 18.1% of statements
```
