### PR TITLE
Add support for user attribute "nickname"

### DIFF
--- a/auth0/resource_auth0_user.go
+++ b/auth0/resource_auth0_user.go
@@ -156,7 +156,7 @@ func buildUser(d *schema.ResourceData) *management.User {
 		}
 	}
 
-	if u.Username != nil || u.Password != nil || u.EmailVerified != nil || u.PhoneVerified != nil || u.Nickname != nil {
+	if u.Username != nil || u.Password != nil || u.EmailVerified != nil || u.PhoneVerified != nil {
 		// When updating email_verified, phone_verified, username or password
 		// we need to specify the connection property too.
 		//

--- a/auth0/resource_auth0_user.go
+++ b/auth0/resource_auth0_user.go
@@ -39,6 +39,10 @@ func newUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"nickname": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"password": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -82,6 +86,7 @@ func readUser(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("user_id", u.ID)
 	d.Set("username", u.Username)
+	d.Set("nickname", u.Nickname)
 	d.Set("phone_number", u.PhoneNumber)
 	d.Set("email_verified", u.EmailVerified)
 	d.Set("phone_verified", u.PhoneVerified)
@@ -128,6 +133,7 @@ func buildUser(d *schema.ResourceData) *management.User {
 		ID:            String(d, "user_id"),
 		Connection:    String(d, "connection_name"),
 		Username:      String(d, "username"),
+		Nickname:      String(d, "nickname"),
 		PhoneNumber:   String(d, "phone_number"),
 		EmailVerified: Bool(d, "email_verified"),
 		VerifyEmail:   Bool(d, "verify_email"),
@@ -150,7 +156,7 @@ func buildUser(d *schema.ResourceData) *management.User {
 		}
 	}
 
-	if u.Username != nil || u.Password != nil || u.EmailVerified != nil || u.PhoneVerified != nil {
+	if u.Username != nil || u.Password != nil || u.EmailVerified != nil || u.PhoneVerified != nil || u.Nickname != nil {
 		// When updating email_verified, phone_verified, username or password
 		// we need to specify the connection property too.
 		//

--- a/auth0/resource_auth0_user_test.go
+++ b/auth0/resource_auth0_user_test.go
@@ -40,6 +40,7 @@ func TestAccUserCreateUser(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_user.user", "user_id", "12345"),
 					resource.TestCheckResourceAttr("auth0_user.user", "email", "test@test.com"),
+					resource.TestCheckResourceAttr("auth0_user.user", "nickname", "testnick"),
 					resource.TestCheckResourceAttr("auth0_user.user", "connection_name", "Username-Password-Authentication"),
 				),
 			},
@@ -55,6 +56,7 @@ resource "auth0_user" "user" {
   user_id = "12345"
   email = "test@test.com"
   password = "testtest$12$12"
+  nickname = "testnick"
   user_metadata = <<EOF
 {
   	"foo": "bar",

--- a/auth0/resource_auth0_user_test.go
+++ b/auth0/resource_auth0_user_test.go
@@ -49,13 +49,15 @@ func TestAccUserCreateUser(t *testing.T) {
 }
 
 const testAccUserCreateUser = `
-provider "auth0" {}
+provider "auth0" {
+}
 
 resource "auth0_user" "user" {
   connection_name = "Username-Password-Authentication"
+  username = "test"
   user_id = "12345"
   email = "test@test.com"
-  password = "testtest$12$12"
+  password = "passpass$12$12"
   nickname = "testnick"
   user_metadata = <<EOF
 {

--- a/example/user/main.tf
+++ b/example/user/main.tf
@@ -3,8 +3,9 @@ provider "auth0" {}
 resource "auth0_user" "user" {
   connection_name = "Username-Password-Authentication"
   user_id = "12345"
+  username = "test"
   nickname = "testnick"
   email = "test@test.com"
   email_verified = true
-  password = "testtest$12$12"
-:}
+  password = "passpass$12$12"
+}

--- a/example/user/main.tf
+++ b/example/user/main.tf
@@ -3,7 +3,8 @@ provider "auth0" {}
 resource "auth0_user" "user" {
   connection_name = "Username-Password-Authentication"
   user_id = "12345"
+  nickname = "testnick"
   email = "test@test.com"
   email_verified = true
   password = "testtest$12$12"
-}
+:}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Add support for user attribute `nickname`. 
* Fix testAccUserCreateUser (username is required property)

Output from acceptance testing:

```
➜ make testacc TESTS=TestAccUserCreateUser
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v  -timeout 120m -coverprofile="c.out" -run ^TestAccUserCreateUser
?       github.com/alexkappa/terraform-provider-auth0   [no test files]
=== RUN   TestAccUserCreateUser
--- PASS: TestAccUserCreateUser (0.68s)
PASS
coverage: 11.8% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0     0.701s  coverage: 11.8% of statements


...
```
