### PR TITLE
Use StringInSlice to validate the app_type field for auth0_client

### DIFF
--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -41,6 +41,12 @@ func newClient() *schema.Resource {
 			"app_type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"native", "spa", "regular_web", "non_interactive", "rms",
+					"box", "cloudbees", "concur", "dropbox", "mscrm", "echosign",
+					"egnyte", "newrelic", "office365", "salesforce", "sentry",
+					"sharepoint", "slack", "springcm", "zendesk", "zoom",
+				}, false),
 			},
 			"logo_uri": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
This PR implemented simple validation for the field `app_type` of resource `auth0_client`, this helps avoid sending extra API requests to (and receiving errors from) Auth0 management.

The validation and format follow the sample from [the validation of `auth0_connection`](https://github.com/alexkappa/terraform-provider-auth0/blame/master/auth0/resource_auth0_connection.go#L34) 

Please note that, unlike the `strategy` of `auth0_connection`, the field `app_type` of `auth0_client` is case-sensitive, when I tried `app_type = SPA` I got the following errors

```
Error: 400 Bad Request: Payload validation error: 'Invalid value "SPA"' on property app_type (The type of application this client represents).

```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Thanks 