### PR TITLE
Add tenant example

### DIFF
--- a/example/tenant/main.tf
+++ b/example/tenant/main.tf
@@ -1,0 +1,32 @@
+provider "auth0" {}
+
+resource "auth0_tenant" "tenant" {
+  change_password {
+    enabled = true
+    html    = "${file("./password_reset.html")}"
+  }
+
+  guardian_mfa_page {
+    enabled = true
+    html    = "${file("./guardian_multifactor.html")}"
+  }
+
+  default_audience  = "<client_id>"
+  default_directory = "Connection-Name"
+
+  error_page {
+    html          = "${file("./error.html")}"
+    show_log_link = true
+    url           = "http://mysite/errors"
+  }
+
+  friendly_name = "Tenant Name"
+  picture_url   = "http://mysite/logo.png"
+  support_email = "support@mysite"
+  support_url   = "http://mysite/support"
+  allowed_logout_urls = [
+    "http://mysite/logout"
+  ]
+  session_lifetime = 46000
+  sandbox_version  = "8"
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

There currently is no example on how to use the tenant resource. However, there is one in PR https://github.com/alexkappa/terraform-provider-auth0/pull/90. But I dont think we should have to wait for the documentation to be completed for the tenant resource example to be available for everyone to view.