### PR TITLE
Add EnforcePolicies field to Resource Server

### DIFF
--- a/auth0/resource_auth0_resource_server.go
+++ b/auth0/resource_auth0_resource_server.go
@@ -79,6 +79,10 @@ func newResourceServer() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
+			"enforce_policies": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -119,6 +123,7 @@ func readResourceServer(d *schema.ResourceData, m interface{}) error {
 	d.Set("skip_consent_for_verifiable_first_party_clients", s.SkipConsentForVerifiableFirstPartyClients)
 	d.Set("verification_location", s.VerificationLocation)
 	d.Set("options", s.Options)
+	d.Set("enforce_policies", s.EnforcePolicies)
 	return nil
 }
 
@@ -151,6 +156,7 @@ func buildResourceServer(d *schema.ResourceData) *management.ResourceServer {
 		SkipConsentForVerifiableFirstPartyClients: Bool(d, "skip_consent_for_verifiable_first_party_clients"),
 		VerificationLocation:                      String(d, "verification_location"),
 		Options:                                   Map(d, "options"),
+		EnforcePolicies:                           Bool(d, "enforce_policies"),
 	}
 
 	if v, ok := d.GetOk("scopes"); ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

https://github.com/go-auth0/auth0/pull/54 added EnforcePolicies field to Resource Server in the underlying Go lib.

This MR just adds the field to the Terraform provider.