### PR TITLE
Fix Connection's password_dictionary

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -413,9 +413,6 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 		c.Options = &management.ConnectionOptions{
 			Validation:                   Map(MapData(m), "validation"),
 			PasswordPolicy:               String(MapData(m), "password_policy"),
-			PasswordHistory:              Map(MapData(m), "password_history"),
-			PasswordNoPersonalInfo:       Map(MapData(m), "password_no_personal_info"),
-			PasswordDictionary:           Map(MapData(m), "password_dictionary"),
 			APIEnableUsers:               Bool(MapData(m), "api_enable_users"),
 			BasicProfile:                 Bool(MapData(m), "basic_profile"),
 			ExtAdmin:                     Bool(MapData(m), "ext_admin"),
@@ -477,6 +474,15 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 
 			c.Options.PasswordNoPersonalInfo = make(map[string]interface{})
 			c.Options.PasswordNoPersonalInfo["enable"] = Bool(MapData(m), "enable")
+		})
+
+		List(MapData(m), "password_dictionary").First(func(v interface{}) {
+
+			m := v.(map[string]interface{})
+
+			c.Options.PasswordDictionary = make(map[string]interface{})
+			c.Options.PasswordDictionary["enable"] = Bool(MapData(m), "enable")
+			c.Options.PasswordDictionary["dictionary"] = Slice(MapData(m), "dictionary")
 		})
 	})
 

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -101,9 +101,22 @@ func newConnection() *schema.Resource {
 							},
 						},
 						"password_dictionary": {
-							Type:     schema.TypeMap,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enable": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"dictionary": {
+										Type:     schema.TypeSet,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										Optional: true,
+									},
+								},
+							},
 						},
 						"api_enable_users": {
 							Type:     schema.TypeBool,
@@ -400,6 +413,8 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 		c.Options = &management.ConnectionOptions{
 			Validation:                   Map(MapData(m), "validation"),
 			PasswordPolicy:               String(MapData(m), "password_policy"),
+			PasswordHistory:              Map(MapData(m), "password_history"),
+			PasswordNoPersonalInfo:       Map(MapData(m), "password_no_personal_info"),
 			PasswordDictionary:           Map(MapData(m), "password_dictionary"),
 			APIEnableUsers:               Bool(MapData(m), "api_enable_users"),
 			BasicProfile:                 Bool(MapData(m), "basic_profile"),

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -482,7 +482,7 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 
 			c.Options.PasswordDictionary = make(map[string]interface{})
 			c.Options.PasswordDictionary["enable"] = Bool(MapData(m), "enable")
-			c.Options.PasswordDictionary["dictionary"] = Slice(MapData(m), "dictionary")
+			c.Options.PasswordDictionary["dictionary"] = Set(MapData(m), "dictionary").Slice()
 		})
 	})
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes https://github.com/alexkappa/terraform-provider-auth0/issues/127

Changes proposed in this pull request:

* Turn `password_dictionary` from just a plain map to a more complex resource that has a `enable` field (boolean), and `dictionary` (list of strings).