### PR TITLE
Add PasswordComplexityOptions to Connection and TokenDialect to Resource Server

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -105,6 +105,20 @@ func newConnection() *schema.Resource {
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Optional: true,
 						},
+						"password_complexity_options": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"min_length": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntAtLeast(1),
+									},
+								},
+							},
+						},
 						"api_enable_users": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -317,6 +331,7 @@ func readConnection(d *schema.ResourceData, m interface{}) error {
 			"password_history":               c.Options.PasswordHistory,
 			"password_no_personal_info":      c.Options.PasswordNoPersonalInfo,
 			"password_dictionary":            c.Options.PasswordDictionary,
+			"password_complexity_options":    c.Options.PasswordComplexityOptions,
 			"api_enable_users":               auth0.BoolValue(c.Options.APIEnableUsers),
 			"basic_profile":                  auth0.BoolValue(c.Options.BasicProfile),
 			"ext_admin":                      auth0.BoolValue(c.Options.ExtAdmin),
@@ -462,6 +477,14 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 
 			c.Options.PasswordNoPersonalInfo = make(map[string]interface{})
 			c.Options.PasswordNoPersonalInfo["enable"] = Bool(MapData(m), "enable")
+		})
+
+		List(MapData(m), "password_complexity_options").First(func(v interface{}) {
+
+			m := v.(map[string]interface{})
+
+			c.Options.PasswordComplexityOptions = make(map[string]interface{})
+			c.Options.PasswordComplexityOptions["min_length"] = Int(MapData(m), "min_length")
 		})
 	})
 

--- a/auth0/resource_auth0_resource_server.go
+++ b/auth0/resource_auth0_resource_server.go
@@ -2,6 +2,7 @@ package auth0
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"gopkg.in/auth0.v1"
 	"gopkg.in/auth0.v1/management"
 )
@@ -79,6 +80,14 @@ func newResourceServer() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
+			"token_dialect": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"access_token",
+					"access_token_authz",
+				}, true),
+			},
 		},
 	}
 }
@@ -119,6 +128,7 @@ func readResourceServer(d *schema.ResourceData, m interface{}) error {
 	d.Set("skip_consent_for_verifiable_first_party_clients", s.SkipConsentForVerifiableFirstPartyClients)
 	d.Set("verification_location", s.VerificationLocation)
 	d.Set("options", s.Options)
+	d.Set("token_dialect", s.TokenDialect)
 	return nil
 }
 
@@ -151,6 +161,7 @@ func buildResourceServer(d *schema.ResourceData) *management.ResourceServer {
 		SkipConsentForVerifiableFirstPartyClients: Bool(d, "skip_consent_for_verifiable_first_party_clients"),
 		VerificationLocation:                      String(d, "verification_location"),
 		Options:                                   Map(d, "options"),
+		TokenDialect:                              String(d, "token_dialect"),
 	}
 
 	if v, ok := d.GetOk("scopes"); ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Add `password_complexity_options` to Auth0 `connection`
* Add `token_dialect` to Auth0 `resource_server`

Requires https://github.com/go-auth0/auth0/pull/69 to be merged in first