### PR TITLE
Fixed optionality of email template fields

### DIFF
--- a/auth0/resource_auth0_email_template.go
+++ b/auth0/resource_auth0_email_template.go
@@ -36,7 +36,7 @@ func newEmailTemplate() *schema.Resource {
 			},
 			"body": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 			},
 			"from": {
 				Type:     schema.TypeString,
@@ -44,7 +44,7 @@ func newEmailTemplate() *schema.Resource {
 			},
 			"result_url": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"subject": {
 				Type:     schema.TypeString,
@@ -56,7 +56,7 @@ func newEmailTemplate() *schema.Resource {
 			},
 			"url_lifetime_in_seconds": {
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

According to the API docs, `body` is required, and `result_url` and `url_lifetime_in_seconds` are optional: https://auth0.com/docs/api/management/v2#!/Email_Templates/post_email_templates