### PR TITLE
Allow setting zero values (false, 0, empty string, empty array, etc)

### DIFF
--- a/auth0/resource_data.go
+++ b/auth0/resource_data.go
@@ -1,8 +1,6 @@
 package auth0
 
 import (
-	"reflect"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"gopkg.in/auth0.v1"
 )
@@ -32,15 +30,11 @@ func (md MapData) HasChange(key string) bool {
 
 func (md MapData) GetOkExists(key string) (interface{}, bool) {
 	v, ok := md[key]
-	return v, ok && !isNil(v) && !isZero(v)
+	return v, ok && !isNil(v)
 }
 
 func isNil(v interface{}) bool {
 	return v == nil
-}
-
-func isZero(v interface{}) bool {
-	return reflect.DeepEqual(v, reflect.Zero(reflect.TypeOf(v)).Interface())
 }
 
 var _ Data = (*schema.ResourceData)(nil)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

@alexkappa This one is a weird one, it took me awhile to track it down and you obviously put this logic here for a reason, but I dont know the history behind it.

I noticed that when I set fields to their empty value (false for boolean, 0 for int, empty string for strings, empty list for list; NOT talking about nil value), this Terraform plugin isnt sending the empty values to Auth0. The JSON sent to Auth0 simply omits the field all together, instead of sending the empty value.

At first I thought it was due to the `omitempty` in the go-auth0 lib, as `omitempty` omits ALL empty values, not just nulls. But go-auth0 is using pointers for all primitives and the JSON marshaller will only omit nulls instead of empty values when dealing with pointers. The exception to the rule of all pointers is arrays; the arrays in go-auth0 arnt pointers and empty arrays are being omitted. So go-auth0 definitely has a bug there concerning empty lists. Documented at https://github.com/go-auth0/auth0/issues/74

But there is still the bug of false and 0 values not being propagated from this Terraform plugin to the go-auth0 lib. Digging through the source of this Terraform plugin, I found the logic where you skip sending the values if they are null or empty. Do you remember the reason you adding the isEmpty logic? It prevents us from using Terraform to set false, empty string, empty list or zero values. I can see why you would want to skip the null values, but skipping empty values does not make any sense to me.