### PR TITLE
Call out support for Terraform 0.12.x in README Re: (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Auth0 Terraform Provider
 Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.11.x
+-	[Terraform](https://www.terraform.io/downloads.html) `0.11.x` || `0.12.x`
 -	[Go](https://golang.org/doc/install) 1.10 (to build the provider plugin)
 
 Building The Provider


### PR DESCRIPTION
Just an edit to make note of the 0.12.x support. 