### PR TITLE
add "enforce_policies" attribute to ResourceServer

### DIFF
--- a/auth0/resource_auth0_resource_server.go
+++ b/auth0/resource_auth0_resource_server.go
@@ -79,6 +79,10 @@ func newResourceServer() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
+			"enforce_policies": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -119,6 +123,7 @@ func readResourceServer(d *schema.ResourceData, m interface{}) error {
 	d.Set("skip_consent_for_verifiable_first_party_clients", s.SkipConsentForVerifiableFirstPartyClients)
 	d.Set("verification_location", s.VerificationLocation)
 	d.Set("options", s.Options)
+	d.Set("enforce_policies", s.EnforcePolicies)
 	return nil
 }
 
@@ -151,6 +156,7 @@ func buildResourceServer(d *schema.ResourceData) *management.ResourceServer {
 		SkipConsentForVerifiableFirstPartyClients: Bool(d, "skip_consent_for_verifiable_first_party_clients"),
 		VerificationLocation:                      String(d, "verification_location"),
 		Options:                                   Map(d, "options"),
+		EnforcePolicies:                           Bool(d, "enforce_policies"),
 	}
 
 	if v, ok := d.GetOk("scopes"); ok {

--- a/auth0/resource_auth0_resource_server_test.go
+++ b/auth0/resource_auth0_resource_server_test.go
@@ -24,6 +24,7 @@ func TestAccResourceServer(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_resource_server.my_resource_server", "token_lifetime", "7200"),
 					resource.TestCheckResourceAttr("auth0_resource_server.my_resource_server", "token_lifetime_for_web", "3600"),
 					resource.TestCheckResourceAttr("auth0_resource_server.my_resource_server", "skip_consent_for_verifiable_first_party_clients", "true"),
+					resource.TestCheckResourceAttr("auth0_resource_server.my_resource_server", "enforce_policies", "true"),
 				),
 			},
 		},
@@ -49,5 +50,6 @@ resource "auth0_resource_server" "my_resource_server" {
   token_lifetime = 7200
   token_lifetime_for_web = 3600
   skip_consent_for_verifiable_first_party_clients = true
+  enforce_policies = true
 }
 `


### PR DESCRIPTION
* Add "enforce_policies" boolean attribute to ResourceServer

Output from acceptance testing:

```
$ make testacc TESTS=TestAccResourceServer 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v  -timeout 120m -coverprofile="c.out" -run ^TestAccResourceServer
?   	github.com/alexkappa/terraform-provider-auth0	[no test files]
=== RUN   TestAccResourceServer
--- PASS: TestAccResourceServer (1.23s)
PASS
coverage: 15.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0	1.248s	coverage: 15.0% of statements
```
