### PR TITLE
[FIX] Missing config in the buildConnection function

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -454,6 +454,9 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 
 			// adfs
 			AdfsServer: String(MapData(m), "adfs_server"),
+
+			// salesforce
+			CommunityBaseURL: String(MapData(m), "community_base_url"),
 		}
 
 		List(MapData(m), "password_history").First(func(v interface{}) {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #139
`
Changes proposed in this pull request:

* Add the required code to the `buildConnection` function.

Output from acceptance testing:
```
$ make testacc TESTS=TestSalesforceCommunityConnection
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v  -timeout 120m -coverprofile="c.out" -run ^TestSalesforceCommunityConnection
?   	github.com/alexkappa/terraform-provider-auth0	[no test files]
=== RUN   TestSalesforceCommunityConnection
--- PASS: TestSalesforceCommunityConnection (0.69s)
PASS
coverage: 16.2% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0	0.971s	coverage: 16.2% of statements
...
```
