### PR TITLE
Fix resource server signing secret

### DIFF
--- a/auth0/resource_auth0_resource_server_test.go
+++ b/auth0/resource_auth0_resource_server_test.go
@@ -14,8 +14,8 @@ func TestAccResourceServer(t *testing.T) {
 			"auth0": Provider(),
 		},
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccResourceServerConfig,
+			{
+				Config: testAccResourceServerConfig_create,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_resource_server.my_resource_server", "name", "Resource Server - Acceptance Test"),
 					resource.TestCheckResourceAttr("auth0_resource_server.my_resource_server", "identifier", "https://api.example.com/v2"),
@@ -27,11 +27,17 @@ func TestAccResourceServer(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_resource_server.my_resource_server", "enforce_policies", "true"),
 				),
 			},
+			{
+				Config: testAccResourceServerConfig_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_resource_server.my_resource_server", "allow_offline_access", "false"),
+				),
+			},
 		},
 	})
 }
 
-const testAccResourceServerConfig = `
+const testAccResourceServerConfig_create = `
 provider "auth0" {}
 
 resource "auth0_resource_server" "my_resource_server" {
@@ -47,6 +53,29 @@ resource "auth0_resource_server" "my_resource_server" {
   	description = "Create bars"
   }
   allow_offline_access = true
+  token_lifetime = 7200
+  token_lifetime_for_web = 3600
+  skip_consent_for_verifiable_first_party_clients = true
+  enforce_policies = true
+}
+`
+
+const testAccResourceServerConfig_update = `
+provider "auth0" {}
+
+resource "auth0_resource_server" "my_resource_server" {
+  name = "Resource Server - Acceptance Test"
+  identifier = "https://api.example.com/v2"
+  signing_alg = "RS256"
+  scopes {
+  	value = "create:foo"
+  	description = "Create foos"
+  }
+  scopes {
+  	value = "create:bar"
+  	description = "Create bars"
+  }
+  allow_offline_access = false # <--- set to false
   token_lifetime = 7200
   token_lifetime_for_web = 3600
   skip_consent_for_verifiable_first_party_clients = true


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #93 

Changes proposed in this pull request:

* resource/auth0_resource_server: `signing_secret` is now also `Computed: true`. If set it's validated to be at least 16 characters.

Output from acceptance testing:

```
$ make testacc TESTS=TestAccResourceServer
==> Checking that code complies with gofmt requirements...
?       github.com/alexkappa/terraform-provider-auth0   [no test files]
=== RUN   TestAccResourceServer
--- PASS: TestAccResourceServer (1.63s)
```
