### PR TITLE
Fix client is_first_party if set to zero value

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,6 +42,6 @@ resource/auth0_tenant:
   - '**/*tenant.go'
   - '**/*tenant_test.go'
 
-resource/auth0_user:
-  - '**/*user.go'
-  - '**/*user_test.go'
+resource_data:
+  - '**/resource_data.go'
+  - '**/resource_data_test.go'

--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -2,7 +2,9 @@ package auth0
 
 import (
 	"os"
+	"testing"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"gopkg.in/auth0.v2/management"
 )
@@ -53,6 +55,10 @@ func Provider() *schema.Provider {
 		},
 		ConfigureFunc: configure,
 	}
+}
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
 }
 
 func configure(data *schema.ResourceData) (interface{}, error) {

--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -65,6 +65,7 @@ func newClient() *schema.Resource {
 			"oidc_conformant": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"callbacks": {
 				Type:     schema.TypeList,

--- a/auth0/resource_auth0_client_test.go
+++ b/auth0/resource_auth0_client_test.go
@@ -92,7 +92,7 @@ resource "auth0_client" "my_client" {
 }
 `
 
-func TestAccClientBugfix(t *testing.T) {
+func TestAccClientZeroValueCheck(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		Providers: map[string]terraform.ResourceProvider{
@@ -102,20 +102,20 @@ func TestAccClientBugfix(t *testing.T) {
 			{
 				Config: testAccClientConfig_create,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("auth0_client.mds_provider", "name", "Application - Acceptance Test - Zero Value Check"),
-					resource.TestCheckResourceAttr("auth0_client.mds_provider", "is_first_party", "false"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "name", "Application - Acceptance Test - Zero Value Check"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "is_first_party", "false"),
 				),
 			},
 			{
 				Config: testAccClientConfig_update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("auth0_client.mds_provider", "is_first_party", "true"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "is_first_party", "true"),
 				),
 			},
 			{
 				Config: testAccClientConfig_update_again,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("auth0_client.mds_provider", "is_first_party", "false"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "is_first_party", "false"),
 				),
 			},
 		},

--- a/auth0/resource_auth0_client_test.go
+++ b/auth0/resource_auth0_client_test.go
@@ -91,3 +91,54 @@ resource "auth0_client" "my_client" {
   }
 }
 `
+
+func TestAccClientBugfix(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClientConfig_create,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.mds_provider", "name", "foobar"),
+					resource.TestCheckResourceAttr("auth0_client.mds_provider", "is_first_party", "false"),
+				),
+			},
+			{
+				Config: testAccClientConfig_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.mds_provider", "is_first_party", "true"),
+				),
+			},
+			{
+				Config: testAccClientConfig_update_again,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.mds_provider", "is_first_party", "false"),
+				),
+			},
+		},
+	})
+}
+
+const testAccClientConfig_create = `
+resource "auth0_client" "mds_provider" {
+  name = "foobar"
+  is_first_party = false
+}
+`
+
+const testAccClientConfig_update = `
+resource "auth0_client" "mds_provider" {
+  name = "foobar"
+  is_first_party = true
+}
+`
+
+const testAccClientConfig_update_again = `
+resource "auth0_client" "mds_provider" {
+  name = "foobar"
+  is_first_party = false
+}
+`

--- a/auth0/resource_auth0_client_test.go
+++ b/auth0/resource_auth0_client_test.go
@@ -102,7 +102,7 @@ func TestAccClientBugfix(t *testing.T) {
 			{
 				Config: testAccClientConfig_create,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("auth0_client.mds_provider", "name", "foobar"),
+					resource.TestCheckResourceAttr("auth0_client.mds_provider", "name", "Application - Acceptance Test - Zero Value Check"),
 					resource.TestCheckResourceAttr("auth0_client.mds_provider", "is_first_party", "false"),
 				),
 			},
@@ -123,22 +123,22 @@ func TestAccClientBugfix(t *testing.T) {
 }
 
 const testAccClientConfig_create = `
-resource "auth0_client" "mds_provider" {
-  name = "foobar"
+resource "auth0_client" "my_client" {
+  name = "Application - Acceptance Test - Zero Value Check"
   is_first_party = false
 }
 `
 
 const testAccClientConfig_update = `
-resource "auth0_client" "mds_provider" {
-  name = "foobar"
+resource "auth0_client" "my_client" {
+  name = "Application - Acceptance Test - Zero Value Check"
   is_first_party = true
 }
 `
 
 const testAccClientConfig_update_again = `
-resource "auth0_client" "mds_provider" {
-  name = "foobar"
+resource "auth0_client" "my_client" {
+  name = "Application - Acceptance Test - Zero Value Check"
   is_first_party = false
 }
 `

--- a/auth0/resource_data.go
+++ b/auth0/resource_data.go
@@ -11,6 +11,10 @@ import (
 // methods defined below.
 type Data interface {
 
+	// IsNewResource reports whether or not the resource is seen for the first
+	// time. If so, checks for change won't be carried out.
+	IsNewResource() bool
+
 	// HasChange reports whether or not the given key has been changed.
 	HasChange(key string) bool
 
@@ -24,6 +28,10 @@ type Data interface {
 // MapData wraps a map satisfying the Data interface, so it can be used in the
 // accessor methods defined below.
 type MapData map[string]interface{}
+
+func (md MapData) IsNewResource() bool {
+	return false
+}
 
 func (md MapData) HasChange(key string) bool {
 	_, ok := md[key]
@@ -48,7 +56,7 @@ var _ Data = (*schema.ResourceData)(nil)
 // String accesses the value held by key and type asserts it to a pointer to a
 // string.
 func String(d Data, key string) (s *string) {
-	if d.HasChange(key) {
+	if d.IsNewResource() || d.HasChange(key) {
 		v, ok := d.GetOkExists(key)
 		if ok {
 			s = auth0.String(v.(string))
@@ -60,7 +68,7 @@ func String(d Data, key string) (s *string) {
 // Int accesses the value held by key and type asserts it to a pointer to a
 // int.
 func Int(d Data, key string) (i *int) {
-	if d.HasChange(key) {
+	if d.IsNewResource() || d.HasChange(key) {
 		v, ok := d.GetOkExists(key)
 		if ok {
 			i = auth0.Int(v.(int))
@@ -72,7 +80,7 @@ func Int(d Data, key string) (i *int) {
 // Bool accesses the value held by key and type asserts it to a pointer to a
 // bool.
 func Bool(d Data, key string) (b *bool) {
-	if d.HasChange(key) {
+	if d.IsNewResource() || d.HasChange(key) {
 		v, ok := d.GetOkExists(key)
 		if ok {
 			b = auth0.Bool(v.(bool))
@@ -83,7 +91,7 @@ func Bool(d Data, key string) (b *bool) {
 
 // Slice accesses the value held by key and type asserts it to a slice.
 func Slice(d Data, key string) (s []interface{}) {
-	if d.HasChange(key) {
+	if d.IsNewResource() || d.HasChange(key) {
 		v, ok := d.GetOkExists(key)
 		if ok {
 			s = v.([]interface{})
@@ -94,7 +102,7 @@ func Slice(d Data, key string) (s []interface{}) {
 
 // Map accesses the value held by key and type asserts it to a map.
 func Map(d Data, key string) (m map[string]interface{}) {
-	if d.HasChange(key) {
+	if d.IsNewResource() || d.HasChange(key) {
 		v, ok := d.GetOkExists(key)
 		if ok {
 			m = v.(map[string]interface{})
@@ -109,7 +117,7 @@ func Map(d Data, key string) (m map[string]interface{}) {
 // The iterator can go over all the items in the list or just the first one,
 // which is a common use case for defining nested schemas in Terraform.
 func List(d Data, key string) *iterator {
-	if d.HasChange(key) {
+	if d.IsNewResource() || d.HasChange(key) {
 		v, ok := d.GetOkExists(key)
 		if ok {
 			return &iterator{v.([]interface{})}
@@ -121,7 +129,7 @@ func List(d Data, key string) *iterator {
 // Set accesses the value held by key, type asserts it to a set and returns an
 // iterator able to go over the items of the list.
 func Set(d Data, key string) *iterator {
-	if d.HasChange(key) {
+	if d.IsNewResource() || d.HasChange(key) {
 		v, ok := d.GetOkExists(key)
 		if ok {
 			if s, ok := v.(*schema.Set); ok {


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #96

Changes proposed in this pull request:

* resource/auth0_client: fixes `is_first_party` setting if set to zero value.
* resource_data: checks for `IsNewResource() || HasChange()` instead of only `HasChange()`.

Output from acceptance testing:

```
$ make testacc
...
PASS
coverage: 79.7% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0	15.436s	coverage: 79.7% of statements
```
