### PR TITLE
Add support for client secret rotation

### DIFF
--- a/auth0/resource_auth0_client_test.go
+++ b/auth0/resource_auth0_client_test.go
@@ -100,20 +100,20 @@ func TestAccClientZeroValueCheck(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClientConfig_create,
+				Config: testAccClientConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client.my_client", "name", "Application - Acceptance Test - Zero Value Check"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "is_first_party", "false"),
 				),
 			},
 			{
-				Config: testAccClientConfig_update,
+				Config: testAccClientConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client.my_client", "is_first_party", "true"),
 				),
 			},
 			{
-				Config: testAccClientConfig_update_again,
+				Config: testAccClientConfigUpdateAgain,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client.my_client", "is_first_party", "false"),
 				),
@@ -122,23 +122,63 @@ func TestAccClientZeroValueCheck(t *testing.T) {
 	})
 }
 
-const testAccClientConfig_create = `
+const testAccClientConfigCreate = `
 resource "auth0_client" "my_client" {
   name = "Application - Acceptance Test - Zero Value Check"
   is_first_party = false
 }
 `
 
-const testAccClientConfig_update = `
+const testAccClientConfigUpdate = `
 resource "auth0_client" "my_client" {
   name = "Application - Acceptance Test - Zero Value Check"
   is_first_party = true
 }
 `
 
-const testAccClientConfig_update_again = `
+const testAccClientConfigUpdateAgain = `
 resource "auth0_client" "my_client" {
   name = "Application - Acceptance Test - Zero Value Check"
   is_first_party = false
+}
+`
+
+func TestAccClientRotateSecret(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClientConfigRotateSecret,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "name", "Application - Acceptance Test - Rotate Secret"),
+				),
+			},
+			{
+				Config: testAccClientConfigRotateSecretUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "client_secret_rotation_trigger.triggered_at", "2018-01-02T23:12:01Z"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "client_secret_rotation_trigger.triggered_by", "alex"),
+				),
+			},
+		},
+	})
+}
+
+const testAccClientConfigRotateSecret = `
+resource "auth0_client" "my_client" {
+  name = "Application - Acceptance Test - Rotate Secret"
+}
+`
+
+const testAccClientConfigRotateSecretUpdate = `
+resource "auth0_client" "my_client" {
+  name = "Application - Acceptance Test - Rotate Secret"
+  client_secret_rotation_trigger = {
+    triggered_at = "2018-01-02T23:12:01Z"
+    triggered_by = "alex"
+  }
 }
 `


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Fixes #152 

Changes proposed in this pull request:

* resource/auth0_client: support rotating `client_secret` by changing the value of `client_secret_rotation_trigger`.

How it works, given a client resource as the following:
```
resource "auth0_client" "my_client" {
  name = "Application - Acceptance Test - Rotate Secret"
}
```

if we change the value of `client_secret_rotation_trigger` it will trigger the `client_secret` to rotate.

```
resource "auth0_client" "my_client" {
  name = "Application - Acceptance Test - Rotate Secret"
  client_secret_rotation_trigger = {
    triggered_at = "2018-01-02T23:12:01Z"
    triggered_by = "alex"
  }
}
```

Note: the contents of `client_secret_rotation_trigger` are arbitrary and can be set to any value the user desires.

Output from acceptance testing:

```
$ make testacc TESTS=TestAccClientRotateSecret      [16:39:09]
==> Checking that code complies with gofmt requirements...
?       github.com/alexkappa/terraform-provider-auth0   [no test files]
=== RUN   TestAccClientRotateSecret
--- PASS: TestAccClientRotateSecret (1.70s)
PASS
coverage: 15.1% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0     1.751s  coverage: 15.1% of statements
```
