### PR TITLE
Fix null scope issue

### DIFF
--- a/auth0/resource_auth0_client_grant.go
+++ b/auth0/resource_auth0_client_grant.go
@@ -98,8 +98,11 @@ func buildClientGrant(d *schema.ResourceData) *management.ClientGrant {
 	g := &management.ClientGrant{
 		ClientID: String(d, "client_id"),
 		Audience: String(d, "audience"),
-		Scope:    Slice(d, "scope"),
 	}
-
+	if scope, ok := d.GetOk("scope"); ok {
+		g.Scope = scope.([]interface{})
+	} else {
+		g.Scope = []interface{}{}
+	}
 	return g
 }

--- a/auth0/resource_auth0_client_grant_test.go
+++ b/auth0/resource_auth0_client_grant_test.go
@@ -18,11 +18,17 @@ func TestAccClientGrant(t *testing.T) {
 				Config: testAccClientGrantConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client_grant.my_client_grant", "audience", "https://api.example.com/client-grant-test"),
-					resource.TestCheckResourceAttr("auth0_client_grant.my_client_grant", "scope.0", "create:foo"),
+					resource.TestCheckResourceAttr("auth0_client_grant.my_client_grant", "scope.#", "0"),
 				),
 			},
 			{
 				Config: testAccClientGrantConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client_grant.my_client_grant", "scope.0", "create:foo"),
+				),
+			},
+			{
+				Config: testAccClientGrantConfigUpdateAgain,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_client_grant.my_client_grant", "scope.#", "0"),
 				),
@@ -56,7 +62,7 @@ resource "auth0_resource_server" "my_resource_server" {
 resource "auth0_client_grant" "my_client_grant" {
   client_id = "${auth0_client.my_client.id}"
   audience = "${auth0_resource_server.my_resource_server.identifier}"
-  scope = [ "create:foo" ]
+  scope = [ ]
 }
 `
 
@@ -85,6 +91,35 @@ resource "auth0_resource_server" "my_resource_server" {
 resource "auth0_client_grant" "my_client_grant" {
   client_id = "${auth0_client.my_client.id}"
   audience = "${auth0_resource_server.my_resource_server.identifier}"
-  scope = [ ] # empty scope
+  scope = [ "create:foo" ] 
+}
+`
+
+const testAccClientGrantConfigUpdateAgain = `
+provider "auth0" {}
+
+resource "auth0_client" "my_client" {
+  name = "Application - Client Grant - Acceptance Test"
+  custom_login_page_on = true
+  is_first_party = true
+}
+
+resource "auth0_resource_server" "my_resource_server" {
+  name = "Resource Server - Client Grant - Acceptance Test"
+  identifier = "https://api.example.com/client-grant-test"
+  scopes {
+       value = "create:foo"
+       description = "Create foos"
+  }
+  scopes {
+       value = "create:bar"
+       description = "Create bars"
+  }
+}
+
+resource "auth0_client_grant" "my_client_grant" {
+  client_id = "${auth0_client.my_client.id}"
+  audience = "${auth0_resource_server.my_resource_server.identifier}"
+  scope = [ ]
 }
 `


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #159

Changes proposed in this pull request:

* Check if scope was defined. If not, create an empty slice instead of leaving null.
* Add test to verify:
    * Creating a `auth0_client_grant` with no scopes (`scope = [ ]`).
    * Updating to add a scope (`scope = [ "create:foo" ]`).
    * Updating again to remove any scopes (`scope = [  ]`).

