### PR TITLE
Add additional optional user profile attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,23 @@ In order to test the provider, you can simply run `make test`.
 $ make test
 ```
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
-
-*Note:* Acceptance tests create real resources, and often cost money to run.
+In order to run the full suite of Acceptance tests, the following environment variables must be set:
 
 ```sh
-$ make testacc
+AUTH0_DOMAIN=your-tenant.auth0.com
+AUTH0_CLIENT_ID=xyz
+AUTH0_CLIENT_SECRET=xyz
 ```
+
+Then, run `make testacc`. 
+
+*Note:* The acceptance tests make calls to a real Auth0 tenant, and create real resources. Certain tests, for example
+for custom domains (`TestAccCustomDomain`), also require a paid Auth0 subscription to be able to run successfully. 
+
+At the time of writing, the following configuration steps are also required for the test tenant:
+
+* The `Username-Password-Authentication` connection must have _Requires Username_ option enabled for the user tests to 
+succesfully run.
+
+
+

--- a/auth0/resource_auth0_user.go
+++ b/auth0/resource_auth0_user.go
@@ -42,6 +42,18 @@ func newUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"family_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"given_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"nickname": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -83,6 +95,14 @@ func newUser() *schema.Resource {
 				ValidateFunc:     validation.ValidateJsonString,
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
+			"blocked": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"picture": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"roles": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -107,12 +127,17 @@ func readUser(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("user_id", u.ID)
 	d.Set("username", u.Username)
+	d.Set("name", u.Name)
+	d.Set("family_name", u.FamilyName)
+	d.Set("given_name", u.GivenName)
 	d.Set("nickname", u.Nickname)
 	d.Set("email", u.Email)
 	d.Set("email_verified", u.EmailVerified)
 	d.Set("verify_email", u.VerifyEmail)
 	d.Set("phone_number", u.PhoneNumber)
 	d.Set("phone_verified", u.PhoneVerified)
+	d.Set("blocked", u.Blocked)
+	d.Set("picture", u.Picture)
 
 	userMeta, err := structure.FlattenJsonToString(u.UserMetadata)
 	if err != nil {
@@ -201,6 +226,9 @@ func buildUser(d *schema.ResourceData) (u *management.User, err error) {
 	u.ID = String(d, "user_id")
 	u.Connection = String(d, "connection_name")
 	u.Username = String(d, "username")
+	u.Name = String(d, "name")
+	u.FamilyName = String(d, "family_name")
+	u.GivenName = String(d, "given_name")
 	u.Nickname = String(d, "nickname")
 	u.PhoneNumber = String(d, "phone_number")
 	u.EmailVerified = Bool(d, "email_verified")
@@ -208,6 +236,8 @@ func buildUser(d *schema.ResourceData) (u *management.User, err error) {
 	u.PhoneVerified = Bool(d, "phone_verified")
 	u.Email = String(d, "email")
 	u.Password = String(d, "password")
+	u.Blocked = Bool(d, "blocked")
+	u.Picture = String(d, "picture")
 
 	u.UserMetadata, err = JSON(d, "user_metadata")
 	if err != nil {

--- a/auth0/resource_auth0_user_test.go
+++ b/auth0/resource_auth0_user_test.go
@@ -39,9 +39,13 @@ func TestAccUser(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_user.user", "user_id", "auth0|12345"),
 					resource.TestCheckResourceAttr("auth0_user.user", "email", "test@test.com"),
-					resource.TestCheckResourceAttr("auth0_user.user", "nickname", "testnick"),
+					resource.TestCheckResourceAttr("auth0_user.user", "name", "Firstname Lastname"),
+					resource.TestCheckResourceAttr("auth0_user.user", "family_name", "Lastname"),
+					resource.TestCheckResourceAttr("auth0_user.user", "given_name", "Firstname"),
+					resource.TestCheckResourceAttr("auth0_user.user", "nickname", "some.nickname"),
 					resource.TestCheckResourceAttr("auth0_user.user", "connection_name", "Username-Password-Authentication"),
 					resource.TestCheckResourceAttr("auth0_user.user", "roles.#", "0"),
+					resource.TestCheckResourceAttr("auth0_user.user", "picture", "https://www.example.com/a-valid-picture-url.jpg"),
 				),
 			},
 			{
@@ -67,11 +71,15 @@ provider auth0 {}
 
 resource auth0_user user {
   connection_name = "Username-Password-Authentication"
-  username = "test"
+  username = "unique_username"
   user_id = "12345"
   email = "test@test.com"
   password = "passpass$12$12"
-  nickname = "testnick"
+  name = "Firstname Lastname"
+  given_name = "Firstname"
+  family_name = "Lastname"
+  nickname = "some.nickname"
+  picture = "https://www.example.com/a-valid-picture-url.jpg"
   user_metadata = <<EOF
 {
   	"foo": "bar",
@@ -92,11 +100,15 @@ provider auth0 {}
 
 resource auth0_user user {
   connection_name = "Username-Password-Authentication"
-  username = "test"
+  username = "unique_username"
   user_id = "12345"
   email = "test@test.com"
   password = "passpass$12$12"
-  nickname = "testnick"
+  name = "Firstname Lastname"
+  given_name = "Firstname"
+  family_name = "Lastname"
+  nickname = "some.nickname"
+  picture = "https://www.example.com/a-valid-picture-url.jpg"
   roles = [ auth0_role.owner.id, auth0_role.admin.id ]
   user_metadata = <<EOF
 {
@@ -128,11 +140,15 @@ provider auth0 {}
 
 resource auth0_user user {
   connection_name = "Username-Password-Authentication"
-  username = "test"
+  username = "unique_username"
   user_id = "12345"
   email = "test@test.com"
   password = "passpass$12$12"
-  nickname = "testnick"
+  name = "Firstname Lastname"
+  given_name = "Firstname"
+  family_name = "Lastname"
+  nickname = "some.nickname"
+  picture = "https://www.example.com/a-valid-picture-url.jpg"
   roles = [ auth0_role.admin.id ]
   user_metadata = <<EOF
 {

--- a/example/user/main.tf
+++ b/example/user/main.tf
@@ -3,11 +3,13 @@ provider "auth0" {}
 resource "auth0_user" "user" {
   connection_name = "Username-Password-Authentication"
   user_id = "12345"
-  username = "test"
-  nickname = "testnick"
+  username = "unique_username"
+  name = "Firstname Lastname"
+  nickname = "some.nickname"
   email = "test@test.com"
   email_verified = true
   password = "passpass$12$12"
+  picture = "https://www.example.com/a-valid-picture-url.jpg"
   roles = [ auth0_role.admin.id ]
 }
 

--- a/website/docs/r/user.html.md
+++ b/website/docs/r/user.html.md
@@ -15,8 +15,11 @@ With this resource, you can manage user identities, including resetting password
 resource "auth0_user" "user" {
   connection_name = "Username-Password-Authentication"
   user_id = "12345"
-  username = "test"
-  nickname = "testnick"
+  username = "unique_username"
+  name = "Firstname Lastname"
+  given_name = "Firstname"
+  family_name = "Lastname"
+  nickname = "some.nickname"
   email = "test@test.com"
   email_verified = true
   password = "passpass$12$12"


### PR DESCRIPTION
Adds the optional user profile attributes `name`, `family_name`, `given_name`, `blocked` and `picture`, which may be useful to set during user resource creation/modification. 

Available user profile attributes are detailed here: https://auth0.com/docs/users/references/user-profile-structure#user-profile-attributes