### PR TITLE
Add enabled_locales property to tenant settings

### DIFF
--- a/auth0/resource_auth0_tenant.go
+++ b/auth0/resource_auth0_tenant.go
@@ -118,6 +118,11 @@ func newTenant() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"enabled_locales": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
 			"flags": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -254,6 +259,7 @@ func readTenant(d *schema.ResourceData, m interface{}) error {
 	d.Set("session_lifetime", t.SessionLifetime)
 	d.Set("sandbox_version", t.SandboxVersion)
 	d.Set("idle_session_lifetime", t.IdleSessionLifetime)
+	d.Set("enabled_locales", t.EnabledLocales)
 
 	if flags := t.Flags; flags != nil {
 		d.Set("flags", []map[string]interface{}{
@@ -317,6 +323,7 @@ func buildTenant(d *schema.ResourceData) *management.Tenant {
 		SessionLifetime:     Int(d, "session_lifetime"),
 		SandboxVersion:      String(d, "sandbox_version"),
 		IdleSessionLifetime: Int(d, "idle_session_lifetime"),
+		EnabledLocales:      Slice(d, "enabled_locales"),
 	}
 
 	List(d, "change_password").First(func(v interface{}) {

--- a/auth0/resource_auth0_tenant_test.go
+++ b/auth0/resource_auth0_tenant_test.go
@@ -34,6 +34,9 @@ func TestAccTenant(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "session_lifetime", "1080"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "sandbox_version", "8"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "idle_session_lifetime", "720"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.0", "en"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.1", "de"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.2", "fr"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.universal_login", "true"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.disable_clickjack_protection_headers", "true"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.enable_public_signup_user_exists_error", "true"),
@@ -74,6 +77,7 @@ resource "auth0_tenant" "my_tenant" {
 	session_lifetime = 1080
 	sandbox_version = "8"
 	idle_session_lifetime = 720
+	enabled_locales = ["en", "de", "fr"]
 	flags {
 		universal_login = true
 		disable_clickjack_protection_headers = true

--- a/example/tenant/main.tf
+++ b/example/tenant/main.tf
@@ -29,4 +29,5 @@ resource "auth0_tenant" "tenant" {
   ]
   session_lifetime = 46000
   sandbox_version  = "8"
+  enabled_locales = ["en"]
 }


### PR DESCRIPTION
Adds the `enabled_locales` property to the tenant settings. This allows users to set the supported languages for the Universal Login - see https://auth0.com/docs/universal-login/i18n#setting-the-tenant-supported-languages.