### PR TITLE
add "auth0_global_client" resource

### DIFF
--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -42,6 +42,7 @@ func Provider() *schema.Provider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"auth0_client":          newClient(),
+			"auth0_global_client":   newGlobalClient(),
 			"auth0_client_grant":    newClientGrant(),
 			"auth0_connection":      newConnection(),
 			"auth0_custom_domain":   newCustomDomain(),

--- a/auth0/resource_auth0_global_client.go
+++ b/auth0/resource_auth0_global_client.go
@@ -1,0 +1,45 @@
+package auth0
+
+import (
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"gopkg.in/auth0.v3/management"
+)
+
+func newGlobalClient() *schema.Resource {
+	client := newClient()
+	client.Create = createGlobalClient
+	client.Delete = deleteGlobalClient
+
+	name := client.Schema["name"]
+	name.Required = false
+	name.Computed = true
+
+	return client
+}
+
+func createGlobalClient(d *schema.ResourceData, m interface{}) error {
+	if err := readGlobalClientId(d, m); err != nil {
+		return err
+	}
+	return updateClient(d, m)
+}
+
+func readGlobalClientId(d *schema.ResourceData, m interface{}) error {
+	api := m.(*management.Management)
+	clients, err := api.Client.List(management.Parameter("is_global", "true"), management.WithFields("client_id"))
+	if err != nil {
+		return err
+	}
+	if len(clients.Clients) == 0 {
+		return errors.New("no auth0 global client found")
+	}
+	d.SetId(clients.Clients[0].GetClientID())
+	return nil
+}
+
+func deleteGlobalClient(d *schema.ResourceData, m interface{}) error {
+	return nil
+}

--- a/auth0/resource_auth0_global_client_test.go
+++ b/auth0/resource_auth0_global_client_test.go
@@ -1,0 +1,83 @@
+package auth0
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccGlobalClient(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				/* Update the custom login page and its enabled flag */
+				Config: testAccGlobalClientConfigWithCustomLogin,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("auth0_global_client.global", "client_id"),
+					resource.TestCheckResourceAttrSet("auth0_global_client.global", "client_secret"),
+					resource.TestCheckResourceAttr("auth0_global_client.global", "custom_login_page", "<html>TEST123</html>"),
+					resource.TestCheckResourceAttr("auth0_global_client.global", "custom_login_page_on", "true"),
+				),
+			},
+			{
+				/* Delete the resource which should cause no change in auth0 configuration as the delete operation is a no op */
+				Config: testAccGlobalClientConfigEmpty,
+				Check: resource.ComposeTestCheckFunc(
+					func(state *terraform.State) error {
+						for _, m := range state.Modules {
+							if len(m.Resources) > 0 {
+								if _, ok := m.Resources["auth0_global_client.global"]; ok {
+									return errors.New("auth0_global_client.global exists when it should have been removed")
+								}
+							}
+						}
+						return nil
+					},
+				),
+			},
+			{
+				/* Create the resource again with no config settings and verify the values are set to what they were in step 2*/
+				Config:             testAccGlobalClientConfigDefault,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_global_client.global", "custom_login_page", "<html>TEST123</html>"),
+					resource.TestCheckResourceAttr("auth0_global_client.global", "custom_login_page_on", "true"),
+				),
+			},
+
+			{
+				/* Disable custom login */
+				Config: testAccGlobalClientConfigNoCustomLogin,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_global_client.global", "custom_login_page_on", "false"),
+				),
+			},
+		},
+	})
+}
+
+const testAccGlobalClientConfigEmpty = `
+`
+
+const testAccGlobalClientConfigDefault = `
+resource "auth0_global_client" "global" {
+}
+`
+
+const testAccGlobalClientConfigWithCustomLogin = `
+resource "auth0_global_client" "global" {
+    custom_login_page = "<html>TEST123</html>"
+    custom_login_page_on = true
+}
+`
+
+const testAccGlobalClientConfigNoCustomLogin = `
+resource "auth0_global_client" "global" {
+    custom_login_page_on = false
+}
+`

--- a/example/global_client/main.tf
+++ b/example/global_client/main.tf
@@ -1,0 +1,25 @@
+provider "auth0" {}
+
+resource "auth0_global_client" "global" {
+    // Auth0 Universal Login - Custom Login Page
+    custom_login_page_on = true
+    custom_login_page = <<PAGE
+<html>
+    <head><title>My Custom Login Page</title></head>
+    <body>
+        I should probably have a login form here
+    </body>
+</html>
+PAGE
+    callbacks = [ "http://somehostname.com/a/callback" ]
+}
+
+// Generally should never be used as it is non-expiring access token to every part of your auth0 tenant
+output "auth0_global_client_id" {
+    value = auth0_global_client.global.client_id
+}
+
+output "auth0_global_client_secret" {
+    value = auth0_global_client.global.client_secret
+    sensitive = true
+}


### PR DESCRIPTION
* Adds ability to enable and manage html of Universal Custom Login page

```
$ make testacc TESTS=TestAccTenant
==> Checking that code complies with gofmt requirements...
?   	github.com/terraform-providers/terraform-provider-auth0	[no test files]
=== RUN   TestAccTenant
--- PASS: TestAccTenant (1.76s)
PASS
coverage: 15.2% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0	1.989s	coverage: 15.2% of statements
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/random	0.186s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/validation	0.227s	coverage: 0.0% of statements [no tests to run]

```
