### PR TITLE
Set CGO_ENABLED=0 in build environment for release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
 
     - name: Build
       run: make build
+      env:
+        CGO_ENABLED: 0
 
     - name: Test
       run: make testacc OPTS=-coverprofile=c.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,4 @@ jobs:
         args: --skip-validate --release-notes release-notes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CGO_ENABLED: 0


### PR DESCRIPTION
This fixes an issue where the plugin fails when running inside an alpine-based Docker container. See  https://github.com/alexkappa/terraform-provider-auth0/issues/175.