### PR TITLE
added support for github connection

### DIFF
--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -498,3 +498,62 @@ resource "auth0_connection" "google_oauth2" {
 	}
 }
 `
+
+func TestAccConnectionGitHub(t *testing.T) {
+
+	rand := random.String(6)
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: random.Template(testAccConnectionGitHubConfig, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_connection.github", "name", "Acceptance-Test-GitHub-{{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_connection.github", "strategy", "github"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.client_id", "client-id"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.client_secret", "client-secret"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.#", "20"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.881205744", "email"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.4080487570", "profile"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.862208977", "follow"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.347111084", "read_repo_hook"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.718177942", "admin_public_key"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.2480957806", "write_public_key"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.356496889", "write_repo_hook"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.3006585776", "write_org"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.855904415", "read_user"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.1560560783", "admin_repo_hook"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.2933527251", "admin_org"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.1314370975", "repo"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.2175618052", "repo_status"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.188173322", "read_org"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.133261078", "gist"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.1820025999", "repo_deployment"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.3220703903", "public_repo"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.2092139895", "notifications"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.672436223", "delete_repo"),
+					resource.TestCheckResourceAttr("auth0_connection.github", "options.0.scopes.2296398814", "read_public_key"),
+				),
+			},
+		},
+	})
+}
+
+const testAccConnectionGitHubConfig = `
+
+resource "auth0_connection" "github" {
+	name = "Acceptance-Test-GitHub-{{.random}}"
+	strategy = "github"
+	options {
+		client_id = "client-id"
+		client_secret = "client-secret"
+		scopes = [ "email", "profile", "read_user", "follow", "public_repo", "repo", "repo_deployment", "repo_status", 
+				   "delete_repo", "notifications", "gist", "read_repo_hook", "write_repo_hook", "admin_repo_hook",
+				   "read_org", "admin_org", "read_public_key", "write_public_key", "admin_public_key", "write_org"
+		]
+	}
+}
+`

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -20,8 +20,8 @@ func flattenConnectionOptions(options interface{}) []interface{} {
 	// 	m = flattenConnectionOptionsApple(o)
 	// case *management.ConnectionOptionsLinkedin:
 	// 	m = flattenConnectionOptionsLinkedin(o)
-	// case *management.ConnectionOptionsGitHub:
-	// 	m = flattenConnectionOptionsGitHub(o)
+	case *management.ConnectionOptionsGitHub:
+		m = flattenConnectionOptionsGitHub(o)
 	// case *management.ConnectionOptionsWindowsLive:
 	// 	m = flattenConnectionOptionsWindowsLive(o)
 	case *management.ConnectionOptionsSalesforce:
@@ -39,6 +39,15 @@ func flattenConnectionOptions(options interface{}) []interface{} {
 	}
 
 	return []interface{}{m}
+}
+
+func flattenConnectionOptionsGitHub(o *management.ConnectionOptionsGitHub) interface{} {
+	return map[string]interface{}{
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"scopes":                   o.Scopes(),
+	}
 }
 
 func flattenConnectionOptionsAuth0(o *management.ConnectionOptions) interface{} {
@@ -164,7 +173,8 @@ func expandConnection(d Data) *management.Connection {
 		// case management.ConnectionStrategyFacebook
 		// 	management.ConnectionStrategyApple
 		// 	management.ConnectionStrategyLinkedin
-		// 	management.ConnectionStrategyGitHub
+		case management.ConnectionStrategyGitHub:
+			c.Options = expandConnectionOptionsGitHub(d)
 		// 	management.ConnectionStrategyWindowsLive:
 		case management.ConnectionStrategySalesforce,
 			management.ConnectionStrategySalesforceCommunity,
@@ -181,6 +191,18 @@ func expandConnection(d Data) *management.Connection {
 	})
 
 	return c
+}
+
+func expandConnectionOptionsGitHub(d Data) *management.ConnectionOptionsGitHub {
+	o := &management.ConnectionOptionsGitHub{
+		ClientID:          String(d, "client_id"),
+		ClientSecret:      String(d, "client_secret"),
+		SetUserAttributes: String(d, "set_user_root_attributes"),
+	}
+
+	expandConnectionOptionsScopes(d, o)
+
+	return o
 }
 
 func expandConnectionOptionsAuth0(d Data) *management.ConnectionOptions {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Changes proposed in this pull request:

* Extended `connection` resource in order to support GitHub Connection

Output from acceptance testing:

```
$ make testacc TESTS=TestAccConnectionGitHub
==> Checking that code complies with gofmt requirements...
?   	github.com/terraform-providers/terraform-provider-auth0	[no test files]
=== RUN   TestAccConnectionGitHub
--- PASS: TestAccConnectionGitHub (5.66s)
PASS
coverage: 10.8% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0	6.549s	coverage: 10.8% of statements
?   	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/debug	[no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/random	0.309s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/validation	0.765s	coverage: 0.0% of statements [no tests to run]
...
```
