### PR TITLE
Paswordless connection creation bug

### DIFF
--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -187,6 +187,8 @@ func expandConnection(d Data) *management.Connection {
 			c.Options = expandConnectionOptionsAD(d)
 		case management.ConnectionStrategyAzureAD:
 			c.Options = expandConnectionOptionsAzureAD(d)
+		case management.ConnectionStrategyEmail:
+			c.Options = expandConnectionOptionsEmail(d)
 		}
 	})
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/yieldr/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #191

Changes proposed in this pull request:

There was a missed switch case to expand the connection in case of an `email` strategy.
Because of that, the connection would be created badly and without the totp and email template configurations.
 
Output from acceptance testing:

```
$ make testacc TESTS=TestAccConnectionEmail
=== RUN   TestAccConnectionEmail
--- PASS: TestAccConnectionEmail (8.45s)

...
```
