### PR TITLE
[WIP] add new resource auth0_branding

### DIFF
--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -60,6 +60,7 @@ func init() {
 			"auth0_user":            newUser(),
 			"auth0_tenant":          newTenant(),
 			"auth0_role":            newRole(),
+			"auth0_branding":        newBranding(),
 		},
 		ConfigureFunc: Configure,
 	}

--- a/auth0/resource_auth0_branding.go
+++ b/auth0/resource_auth0_branding.go
@@ -1,0 +1,139 @@
+package auth0
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"gopkg.in/auth0.v4/management"
+)
+
+func newBranding() *schema.Resource {
+	return &schema.Resource{
+		Create: createBranding,
+		Read:   readBranding,
+		Update: updateBranding,
+		Delete: deleteBranding,
+
+		Schema: map[string]*schema.Schema{
+			"colors": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"primary": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"page_background": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"colors.0.page_background_gradient"},
+						},
+						"page_background_gradient": {
+							Type:          schema.TypeList,
+							Optional:      true,
+							MaxItems:      1,
+							ConflictsWith: []string{"colors.0.page_background"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"start": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"end": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"angle_deg": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"favicon_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"logo_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"font": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createBranding(d *schema.ResourceData, m interface{}) error {
+	d.SetId(resource.UniqueId())
+	return updateBranding(d, m)
+}
+
+func readBranding(d *schema.ResourceData, m interface{}) error {
+	api := m.(*management.Management)
+
+	b, err := api.Branding.Read()
+	if err != nil {
+		if mErr, ok := err.(management.Error); ok {
+			if mErr.Status() == http.StatusNotFound {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	d.Set("colors", flattenBrandingColors(b.Colors))
+	d.Set("favicon_url", b.FaviconURL)
+	d.Set("logo_url", b.LogoURL)
+	d.Set("font", flattenBrandingFont(b.Font))
+
+	return nil
+}
+
+func updateBranding(d *schema.ResourceData, m interface{}) error {
+	b := buildBranding(d)
+	api := m.(*management.Management)
+	err := api.Branding.Update(b)
+	if err != nil {
+		return err
+	}
+	return readBranding(d, m)
+}
+
+func deleteBranding(d *schema.ResourceData, m interface{}) error {
+	d.SetId("")
+	return nil
+}
+
+func buildBranding(d *schema.ResourceData) *management.Branding {
+	b := &management.Branding{
+		Colors:     expandBrandingColors(d),
+		FaviconURL: String(d, "favicon_url"),
+		LogoURL:    String(d, "logo_url"),
+		Font:       expandBrandingFont(d),
+	}
+
+	return b
+}

--- a/auth0/resource_auth0_branding_test.go
+++ b/auth0/resource_auth0_branding_test.go
@@ -1,0 +1,76 @@
+package auth0
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccBranding(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBrandingConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_branding.my_branding", "logo_url", "https://mycompany.org/logo.png"),
+					resource.TestCheckResourceAttr("auth0_branding.my_branding", "favicon_url", "https://mycompany.org/favicon.png"),
+					resource.TestCheckResourceAttr("auth0_branding.my_branding", "font.0.url", "https://mycompany.org/font.ttf"),
+					resource.TestCheckResourceAttr("auth0_branding.my_branding", "colors.0.primary", "#ffffff"),
+					resource.TestCheckResourceAttr("auth0_branding.my_branding", "colors.0.page_background", "#000000"),
+				),
+			},
+			{
+				Config: testAccBrandingConfigPageBackgroundGradient,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_branding.my_branding", "colors.0.page_background_gradient.0.type", "linear-gradient"),
+					resource.TestCheckResourceAttr("auth0_branding.my_branding", "colors.0.page_background_gradient.0.start", "#aaaaaa"),
+					resource.TestCheckResourceAttr("auth0_branding.my_branding", "colors.0.page_background_gradient.0.end", "#333333"),
+					resource.TestCheckResourceAttr("auth0_branding.my_branding", "colors.0.page_background_gradient.0.angle_deg", "35"),
+				),
+			},
+		},
+	})
+
+}
+
+const testAccBrandingConfigCreate = `
+resource "auth0_branding" "my_branding" {
+	logo_url    = "https://mycompany.org/logo.png"
+	favicon_url = "https://mycompany.org/favicon.png"
+
+	font {
+		url = "https://mycompany.org/font.ttf"
+	}
+
+	colors {
+		primary         = "#ffffff"
+		page_background = "#000000"
+	}
+}
+`
+
+const testAccBrandingConfigPageBackgroundGradient = `
+resource "auth0_branding" "my_branding" {
+	logo_url    = "https://mycompany.org/logo.png"
+	favicon_url = "https://mycompany.org/favicon.png"
+
+	font {
+		url = "https://mycompany.org/font.ttf"
+	}
+
+	colors {
+		primary = "#ffffff"
+
+		page_background_gradient {
+			type      = "linear-gradient"
+			start     = "#aaaaaa"
+			end       = "#333333"
+			angle_deg = 35
+		}
+	}
+}
+`

--- a/auth0/structure_auth0_branding.go
+++ b/auth0/structure_auth0_branding.go
@@ -58,9 +58,16 @@ func expandBrandingColors(d Data) (colors *management.BrandingColors) {
 
 func expandBrandingFont(d Data) (font *management.BrandingFont) {
 	List(d, "font").Elem(func(d Data) {
-		font = &management.BrandingFont{
-			URL: String(d, "url"),
+		url := String(d, "url")
+
+		// Avoid 400 Bad Request if we send the font object with an empty URL
+		if url != nil {
+			font = &management.BrandingFont{
+				URL: String(d, "url"),
+			}
 		}
+
 	})
+
 	return
 }

--- a/auth0/structure_auth0_branding.go
+++ b/auth0/structure_auth0_branding.go
@@ -1,0 +1,65 @@
+package auth0
+
+import (
+	"gopkg.in/auth0.v4/management"
+)
+
+func flattenBrandingColors(colors *management.BrandingColors) []interface{} {
+	m := make(map[string]interface{})
+
+	if colors != nil {
+		m["primary"] = colors.Primary
+		m["page_background"] = colors.PageBackground
+
+		if colors.PageBackgroundGradient != nil {
+			m["page_background_gradient"] = []interface{}{
+				map[string]interface{}{
+					"type":      colors.PageBackgroundGradient.Type,
+					"start":     colors.PageBackgroundGradient.Start,
+					"end":       colors.PageBackgroundGradient.End,
+					"angle_deg": colors.PageBackgroundGradient.AngleDegree,
+				},
+			}
+		}
+	}
+
+	return []interface{}{m}
+}
+
+func flattenBrandingFont(font *management.BrandingFont) []interface{} {
+	m := make(map[string]interface{})
+
+	if font != nil {
+		m["url"] = font.URL
+	}
+
+	return []interface{}{m}
+}
+
+func expandBrandingColors(d Data) (colors *management.BrandingColors) {
+	List(d, "colors").Elem(func(d Data) {
+		colors = &management.BrandingColors{
+			Primary:        String(d, "primary"),
+			PageBackground: String(d, "page_background"),
+		}
+
+		List(d, "page_background_gradient").Elem(func(d Data) {
+			colors.PageBackgroundGradient = &management.BrandingPageBackgroundGradient{
+				Type:        String(d, "type"),
+				Start:       String(d, "start"),
+				End:         String(d, "end"),
+				AngleDegree: Int(d, "angle_deg"),
+			}
+		})
+	})
+	return
+}
+
+func expandBrandingFont(d Data) (font *management.BrandingFont) {
+	List(d, "font").Elem(func(d Data) {
+		font = &management.BrandingFont{
+			URL: String(d, "url"),
+		}
+	})
+	return
+}

--- a/auth0/structure_auth0_branding.go
+++ b/auth0/structure_auth0_branding.go
@@ -44,6 +44,7 @@ func expandBrandingColors(d Data) (colors *management.BrandingColors) {
 		}
 
 		List(d, "page_background_gradient").Elem(func(d Data) {
+			colors.PageBackground = nil
 			colors.PageBackgroundGradient = &management.BrandingPageBackgroundGradient{
 				Type:        String(d, "type"),
 				Start:       String(d, "start"),

--- a/website/auth0.erb
+++ b/website/auth0.erb
@@ -21,6 +21,7 @@
             <li><a href="/docs/providers/auth0/r/prompt.html">auth0_prompt</a></li>
             <li><a href="/docs/providers/auth0/r/tenant.html">auth0_tenant</a></li>
             <li><a href="/docs/providers/auth0/r/user.html">auth0_user</a></li>
+            <li><a href="/docs/providers/auth0/r/branding.html">auth0_branding</a></li>
           </ul>
         </li>
       </ul>

--- a/website/docs/r/branding.html.md
+++ b/website/docs/r/branding.html.md
@@ -1,0 +1,100 @@
+---
+layout: "auth0"
+page_title: "Auth0: auth0_branding"
+description: |-
+  With this resource, you can configure the branding for the Universal Login Experience.
+---
+
+# auth0_branding
+
+With this resource, you can configure the branding for the Universal Login Experience.
+
+## Example Usage
+
+```hcl
+resource "auth0_branding" "example" {
+  favicon_url = "https://mysite/favicon.png"
+  logo_url    = "https://mysite/logo.png"
+  
+  font {
+    url = "https://mysite/font.ttf"
+  }
+
+  colors {
+    primary         = "#ffffff"
+    page_background = "#000000"
+  }
+}
+```
+
+### With a gradient page background
+
+```hcl
+resource "auth0_branding" "example" {
+  colors {
+    primary = "#ffffff"
+    
+    page_background_gradient {
+      type      = "linear-gradient"
+      start     = "#333333"
+      end       = "#aaaaaa"
+      angle_deg = 35
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+
+* `favicon_url` - (Optional) String. URL for the favicon. Must use HTTPS.
+* `logo_url` - (Optional) String. URL for the logo. Must use HTTPS.
+* `colors` - (Optional) List(Resource). Configuration settings to customized the branding colors. For details see [Colors](#colors). 
+* `font` - (Optional) List(Resource). Configuration settings to customize the font. For details see [Font](#font).
+
+### `colors`
+
+Specify the colors that the universal login experience should use.
+
+For the background, you can either use a static color with `page_background`, or color gradient with `page_background_color`. It is not possible to define both.
+
+#### Arguments
+
+* `primary` - (Optional) String. Accent color.
+* `page_background` - (Optional) String. Page background color. Conflicts with `page_background_gradient`.
+* `page_background_gradient` - (Optional) List(Resource). Configuration settings to define a gradient page background. For details see [Page Background Gradient](#page_background_gradient).  Conflicts with `page_background`.
+
+#### Attributes
+
+### `font`
+
+#### Arguments
+
+* `url` - (Required) String. URL for the custom font. Must use HTTPS.
+
+#### Attributes
+
+### `page_background_gradient`
+
+#### Arguments
+
+* `type` - (Optional) String. The type of gradient. 
+* `start` - (Optional) String. The start color of the gradient.
+* `end` - (Optional) String. The end colors of the gradient.
+* `angle_deg` - (Optional) Number. Degrees that the background gradient is rotated.
+
+#### Attributes
+
+## Attributes Reference
+
+In addition to the arguments listed above, no other attributes are exported.
+
+## Import
+
+auth0_branding can be imported using an arbitrary id, e.g:
+
+```
+$ terraform import auth0_branding.example 123
+```


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Related to #124

Changes proposed in this pull request:

* Add new resource `auth0_branding`

Output from acceptance testing:

```
$ make testacc TESTS=TestAccBranding
==> Checking that code complies with gofmt requirements...
?       github.com/terraform-providers/terraform-provider-auth0 [no test files]
=== RUN   TestAccBranding
--- PASS: TestAccBranding (1.89s)
PASS
coverage: 8.9% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0   1.902s  coverage: 8.9% of statements
?       github.com/terraform-providers/terraform-provider-auth0/auth0/internal/debug    [no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0/internal/random   0.006s  coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0/internal/validation       0.002s  coverage: 0.0% of statements [no tests to run]
```