### PR TITLE
Fix for empty auth0_client.jwt_configuration.scope 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ builds:
   - binary: "terraform-provider-auth0_v{{ .Version }}"
     env:
       - CGO_ENABLED=0
+      - GOFLAGS=-mod=vendor
     goos:
       - darwin
       - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ cache:
   - $GOPATH/pkg/mod
 
 env:
-  - GO111MODULE=on
-  - GOFLAGS=-mod=vendor
+  - GO111MODULE=on GOFLAGS=-mod=vendor
 
 install:
   # This script is used by the Travis build to install a cookie for

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
 
 env:
   - GO111MODULE=on
+  - GOFLAGS=-mod=vendor
 
 install:
   # This script is used by the Travis build to install a cookie for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.0 (Unreleased)
+## 0.9.0 (April 14, 2020)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+## 0.10.0 (Unreleased)
 ## 0.9.0 (April 14, 2020)
 
 BUG FIXES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,7 +8,7 @@ WEBSITE_REPO = github.com/hashicorp/terraform-website
 default: build
 
 build: fmtcheck
-	@go install -mod=vendor
+	@go install
 
 install: build
 	@cp $(GOPATH)/bin/terraform-provider-auth0 ~/.terraform.d/plugins

--- a/auth0/internal/debug/debug.go
+++ b/auth0/internal/debug/debug.go
@@ -3,6 +3,7 @@ package debug
 import (
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -15,9 +16,20 @@ func DumpAttr(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Not found: %s", n)
 		}
 		log.Printf("[DEBUG] Attrs: \n")
-		for key, value := range rs.Primary.Attributes {
-			log.Printf("[DEBUG]\t %s: %q\n", key, value)
+		attributes := rs.Primary.Attributes
+		keys := keys(attributes)
+		sort.Strings(keys)
+		for _, key := range keys {
+			log.Printf("[DEBUG]\t %s: %q\n", key, attributes[key])
 		}
 		return nil
 	}
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -70,7 +70,7 @@ func Configure(data *schema.ResourceData) (interface{}, error) {
 	debug := data.Get("debug").(bool)
 
 	userAgent := fmt.Sprintf("Go-Auth0-SDK/%s; Terraform-SDK/%s",
-		auth0.VersionMajor(),
+		auth0.Version,
 		meta.SDKVersionString())
 
 	return management.New(domain, id, secret,

--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -584,7 +584,7 @@ func expandClient(d *schema.ResourceData) *management.Client {
 
 	List(d, "jwt_configuration").Elem(func(d Data) {
 		c.JWTConfiguration = &management.ClientJWTConfiguration{
-			LifetimeInSeconds: Int(d, "lifetime_in_seconds"),
+			LifetimeInSeconds: Int(d, "lifetime_in_seconds", IsNewResource(), HasChange()),
 			SecretEncoded:     Bool(d, "secret_encoded", IsNewResource()),
 			Algorithm:         String(d, "alg", IsNewResource(), HasChange()),
 			Scopes:            Map(d, "scopes"),

--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -104,6 +104,7 @@ func newClient() *schema.Resource {
 			"jwt_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				MinItems: 1,
 				Elem: &schema.Resource{
@@ -111,6 +112,7 @@ func newClient() *schema.Resource {
 						"lifetime_in_seconds": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 						"secret_encoded": {
 							Type:     schema.TypeBool,
@@ -584,7 +586,7 @@ func expandClient(d *schema.ResourceData) *management.Client {
 		c.JWTConfiguration = &management.ClientJWTConfiguration{
 			LifetimeInSeconds: Int(d, "lifetime_in_seconds"),
 			SecretEncoded:     Bool(d, "secret_encoded", IsNewResource()),
-			Algorithm:         String(d, "alg"),
+			Algorithm:         String(d, "alg", IsNewResource(), HasChange()),
 			Scopes:            Map(d, "scopes"),
 		}
 	})

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/terraform-plugin-sdk v1.9.1
-	gopkg.in/auth0.v4 v4.3.1
+	gopkg.in/auth0.v4 v4.3.3
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/PuerkitoBio/rehttp v0.0.0-20180310210549-11cf6ea5d3e9 h1:VE0eMvNSQI72dADsq4gm5KpNPmt97WgqneTfaS5MWrs=
 github.com/PuerkitoBio/rehttp v0.0.0-20180310210549-11cf6ea5d3e9/go.mod h1:ItsOiHl4XeMOV3rzbZqQRjLc3QQxbE6391/9iNG7rE8=
+github.com/PuerkitoBio/rehttp v1.0.0 h1:aJ7A7YI2lIvOxcJVeUZY4P6R7kKZtLeONjgyKGwOIu8=
+github.com/PuerkitoBio/rehttp v1.0.0/go.mod h1:ItsOiHl4XeMOV3rzbZqQRjLc3QQxbE6391/9iNG7rE8=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
@@ -259,6 +261,8 @@ golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a h1:tImsplftrFpALCYumobsd0
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -357,6 +361,8 @@ gopkg.in/auth0.v4 v4.2.0 h1:pVU7ezBMwKNHY9Tv/a3rlokyxhgo8r8BFFBvsSdBp40=
 gopkg.in/auth0.v4 v4.2.0/go.mod h1:B9QUu0MG0np724IVcwWu/azhsckQ+3/niPVtQEThPlU=
 gopkg.in/auth0.v4 v4.3.1 h1:A8QTYcrMvRCd9pjaupk+BSHJgS0rrS7zMssUZwSgNcM=
 gopkg.in/auth0.v4 v4.3.1/go.mod h1:AXTju4pos7DDjJmMctlRnmdZRfYALW56O3XuDjmEFYs=
+gopkg.in/auth0.v4 v4.3.3 h1:adPjwLB2UoSwUZIbcIKBEe/diMbGvfokZHseqFMq1D8=
+gopkg.in/auth0.v4 v4.3.3/go.mod h1:6ZOcoQequCmURgwJnGIX09/51deRWVRpUaUP8p1Jbpk=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=

--- a/vendor/golang.org/x/oauth2/README.md
+++ b/vendor/golang.org/x/oauth2/README.md
@@ -16,15 +16,16 @@ Or you can manually git clone the repository to
 
 See godoc for further documentation and examples.
 
-* [godoc.org/golang.org/x/oauth2](http://godoc.org/golang.org/x/oauth2)
-* [godoc.org/golang.org/x/oauth2/google](http://godoc.org/golang.org/x/oauth2/google)
+* [godoc.org/golang.org/x/oauth2](https://godoc.org/golang.org/x/oauth2)
+* [godoc.org/golang.org/x/oauth2/google](https://godoc.org/golang.org/x/oauth2/google)
 
 ## Policy for new packages
 
-We no longer accept new provider-specific packages in this repo. For
-defining provider endpoints and provider-specific OAuth2 behavior, we
-encourage you to create packages elsewhere. We'll keep the existing
-packages for compatibility.
+We no longer accept new provider-specific packages in this repo if all
+they do is add a single endpoint variable. If you just want to add a
+single endpoint, add it to the
+[godoc.org/golang.org/x/oauth2/endpoints](https://godoc.org/golang.org/x/oauth2/endpoints)
+package.
 
 ## Report Issues / Send Patches
 

--- a/vendor/golang.org/x/oauth2/transport.go
+++ b/vendor/golang.org/x/oauth2/transport.go
@@ -6,7 +6,7 @@ package oauth2
 
 import (
 	"errors"
-	"io"
+	"log"
 	"net/http"
 	"sync"
 )
@@ -25,9 +25,6 @@ type Transport struct {
 	// Base is the base RoundTripper used to make HTTP requests.
 	// If nil, http.DefaultTransport is used.
 	Base http.RoundTripper
-
-	mu     sync.Mutex                      // guards modReq
-	modReq map[*http.Request]*http.Request // original -> modified
 }
 
 // RoundTrip authorizes and authenticates the request with an
@@ -52,35 +49,22 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	req2 := cloneRequest(req) // per RoundTripper contract
 	token.SetAuthHeader(req2)
-	t.setModReq(req, req2)
-	res, err := t.base().RoundTrip(req2)
 
-	// req.Body is assumed to have been closed by the base RoundTripper.
+	// req.Body is assumed to be closed by the base RoundTripper.
 	reqBodyClosed = true
-
-	if err != nil {
-		t.setModReq(req, nil)
-		return nil, err
-	}
-	res.Body = &onEOFReader{
-		rc: res.Body,
-		fn: func() { t.setModReq(req, nil) },
-	}
-	return res, nil
+	return t.base().RoundTrip(req2)
 }
 
-// CancelRequest cancels an in-flight request by closing its connection.
+var cancelOnce sync.Once
+
+// CancelRequest does nothing. It used to be a legacy cancellation mechanism
+// but now only it only logs on first use to warn that it's deprecated.
+//
+// Deprecated: use contexts for cancellation instead.
 func (t *Transport) CancelRequest(req *http.Request) {
-	type canceler interface {
-		CancelRequest(*http.Request)
-	}
-	if cr, ok := t.base().(canceler); ok {
-		t.mu.Lock()
-		modReq := t.modReq[req]
-		delete(t.modReq, req)
-		t.mu.Unlock()
-		cr.CancelRequest(modReq)
-	}
+	cancelOnce.Do(func() {
+		log.Printf("deprecated: golang.org/x/oauth2: Transport.CancelRequest no longer does anything; use contexts")
+	})
 }
 
 func (t *Transport) base() http.RoundTripper {
@@ -88,19 +72,6 @@ func (t *Transport) base() http.RoundTripper {
 		return t.Base
 	}
 	return http.DefaultTransport
-}
-
-func (t *Transport) setModReq(orig, mod *http.Request) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.modReq == nil {
-		t.modReq = make(map[*http.Request]*http.Request)
-	}
-	if mod == nil {
-		delete(t.modReq, orig)
-	} else {
-		t.modReq[orig] = mod
-	}
 }
 
 // cloneRequest returns a clone of the provided *http.Request.
@@ -115,30 +86,4 @@ func cloneRequest(r *http.Request) *http.Request {
 		r2.Header[k] = append([]string(nil), s...)
 	}
 	return r2
-}
-
-type onEOFReader struct {
-	rc io.ReadCloser
-	fn func()
-}
-
-func (r *onEOFReader) Read(p []byte) (n int, err error) {
-	n, err = r.rc.Read(p)
-	if err == io.EOF {
-		r.runFunc()
-	}
-	return
-}
-
-func (r *onEOFReader) Close() error {
-	err := r.rc.Close()
-	r.runFunc()
-	return err
-}
-
-func (r *onEOFReader) runFunc() {
-	if fn := r.fn; fn != nil {
-		fn()
-		r.fn = nil
-	}
 }

--- a/vendor/gopkg.in/auth0.v4/go.mod
+++ b/vendor/gopkg.in/auth0.v4/go.mod
@@ -3,7 +3,6 @@ module gopkg.in/auth0.v4
 go 1.12
 
 require (
-	github.com/PuerkitoBio/rehttp v0.0.0-20180310210549-11cf6ea5d3e9
-	github.com/hashicorp/go-version v1.2.0
-	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
+	github.com/PuerkitoBio/rehttp v1.0.0
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 )

--- a/vendor/gopkg.in/auth0.v4/go.sum
+++ b/vendor/gopkg.in/auth0.v4/go.sum
@@ -1,6 +1,9 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/PuerkitoBio/rehttp v0.0.0-20180310210549-11cf6ea5d3e9 h1:VE0eMvNSQI72dADsq4gm5KpNPmt97WgqneTfaS5MWrs=
 github.com/PuerkitoBio/rehttp v0.0.0-20180310210549-11cf6ea5d3e9/go.mod h1:ItsOiHl4XeMOV3rzbZqQRjLc3QQxbE6391/9iNG7rE8=
+github.com/PuerkitoBio/rehttp v1.0.0 h1:aJ7A7YI2lIvOxcJVeUZY4P6R7kKZtLeONjgyKGwOIu8=
+github.com/PuerkitoBio/rehttp v1.0.0/go.mod h1:ItsOiHl4XeMOV3rzbZqQRjLc3QQxbE6391/9iNG7rE8=
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -9,6 +12,9 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a h1:tImsplftrFpALCYumobsd0K86vlAs/eXGFms2txfJfA=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/vendor/gopkg.in/auth0.v4/internal/client/client.go
+++ b/vendor/gopkg.in/auth0.v4/internal/client/client.go
@@ -17,7 +17,7 @@ import (
 )
 
 // UserAgent is the default user agent string
-var UserAgent = fmt.Sprintf("Go-Auth0-SDK/v%s", auth0.VersionMajor())
+var UserAgent = fmt.Sprintf("Go-Auth0-SDK/%s", auth0.Version)
 
 func WrapRateLimit(c *http.Client) *http.Client {
 	return &http.Client{

--- a/vendor/gopkg.in/auth0.v4/management/client.go
+++ b/vendor/gopkg.in/auth0.v4/management/client.go
@@ -94,7 +94,7 @@ type ClientJWTConfiguration struct {
 	// true
 	SecretEncoded *bool `json:"secret_encoded,omitempty"`
 
-	Scopes interface{} `json:"scopes,omitempty"`
+	Scopes map[string]interface{} `json:"scopes,omitempty"`
 
 	// Algorithm used to sign JWTs. Can be "HS256" or "RS256"
 	Algorithm *string `json:"alg,omitempty"`

--- a/vendor/gopkg.in/auth0.v4/meta.go
+++ b/vendor/gopkg.in/auth0.v4/meta.go
@@ -1,30 +1,4 @@
 package auth0
 
-import (
-	"strconv"
-
-	"github.com/hashicorp/go-version"
-)
-
-const v = "4.3.0"
-
-var semver *version.Version
-
-func init() {
-	semver = version.Must(version.NewVersion(v))
-}
-
 // Version of this library.
-func Version() string {
-	return semver.String()
-}
-
-// VersionMajor is the major version of this library
-func VersionMajor() string {
-	return strconv.Itoa(semver.Segments()[0])
-}
-
-// SemVer returns the version parsed as semver.
-func SemVer() *version.Version {
-	return semver
-}
+var Version = "4.3.3"

--- a/vendor/gopkg.in/auth0.v4/release
+++ b/vendor/gopkg.in/auth0.v4/release
@@ -4,7 +4,7 @@ set -e
 
 function update_version {
   local version="$1"
-  sed -i.backup "s/const Version =.*/const Version = \"${version}\"/" meta.go
+  sed -i.backup "s/var Version =.*/var Version = \"${version}\"/" meta.go
   rm -rf meta.go.backup
 }
 
@@ -23,6 +23,10 @@ function push_changes {
 
 function main {
   local version="$1"
+  if [[ $version = v* ]]; then
+    echo "version should be in the format X.Y.Z"
+    exit 1
+  fi
   update_version $version
   commit_changes $version
   push_changes $version

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/PuerkitoBio/rehttp v0.0.0-20180310210549-11cf6ea5d3e9
+# github.com/PuerkitoBio/rehttp v1.0.0
 github.com/PuerkitoBio/rehttp
 # github.com/agext/levenshtein v1.2.2
 github.com/agext/levenshtein
@@ -276,7 +276,7 @@ golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
-# golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+# golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 golang.org/x/oauth2
 golang.org/x/oauth2/clientcredentials
 golang.org/x/oauth2/google
@@ -362,7 +362,7 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 google.golang.org/grpc/test/bufconn
-# gopkg.in/auth0.v4 v4.3.1
+# gopkg.in/auth0.v4 v4.3.3
 gopkg.in/auth0.v4
 gopkg.in/auth0.v4/internal/client
 gopkg.in/auth0.v4/internal/tag


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #196 

Changes proposed in this pull request:

- Upgrade `go-auth0/auth0` which defines Scopes as a `map[string]interface{}` instead of an `interface{}`.

The issue is demonstrated by the example below. Notice how only the first instance of `S` ignores `V` during marshal.

```go
type S struct {
	V interface{} `json:"v,omitempty"`
}

for _, s := range []S{
	{V: nil},
	{V: (map[string]interface{})(nil)},
	{V: (*string)(nil)},
	{V: 0},
	{V: ""},
	{V: false},
} {
	b, _ := json.Marshal(s)
	fmt.Printf("%s\n", b)
}
```

```
{}
{"v":null}
{"v":null}
{"v":0}
{"v":""}
{"v":false}
```

See: https://play.golang.org/p/hyMWxh_FVI-

**NOTE**: This fixes the issue where the Auth0 API responds with a `Expected type object but found type null` error. There is a long standing bug of not being able to "clear" slice/map values after they have been set. Go's JSON package will ignores empty as well as nil arrays or maps when the `omitempty` tag is present.