### PR TITLE
resource/auth0_connection: round-trip configuration values and avoid suppressing diffs

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -1,9 +1,7 @@
 package auth0
 
 import (
-	"log"
 	"net/http"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -181,17 +179,10 @@ func newConnection() *schema.Resource {
 							Description: "",
 						},
 						"configuration": {
-							Type:      schema.TypeMap,
-							Elem:      &schema.Schema{Type: schema.TypeString},
-							Sensitive: true,
-							Optional:  true,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								log.Printf(`[DEBUG] DiffSuppressFunc(%q, %q, %q)`, k, old, new)
-								if strings.HasSuffix(k, "%") {
-									return new == old
-								}
-								return strings.HasPrefix(old, "2.0$") || new == old
-							},
+							Type:        schema.TypeMap,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Sensitive:   true,
+							Optional:    true,
 							Description: "",
 						},
 						"client_id": {
@@ -425,7 +416,7 @@ func readConnection(d *schema.ResourceData, m interface{}) error {
 	d.Set("name", c.Name)
 	d.Set("is_domain_connection", c.IsDomainConnection)
 	d.Set("strategy", c.Strategy)
-	d.Set("options", flattenConnectionOptions(c.Options))
+	d.Set("options", flattenConnectionOptions(d, c.Options))
 	d.Set("enabled_clients", c.EnabledClients)
 	d.Set("realms", c.Realms)
 	return nil

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-auth0/auth0/internal/debug"
 	"github.com/terraform-providers/terraform-provider-auth0/auth0/internal/random"
 	"gopkg.in/auth0.v4/management"
 )
@@ -334,7 +333,6 @@ func TestAccConnectionSMS(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.totp.#", "1"),
 					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.totp.0.time_step", "300"),
 					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.totp.0.length", "6"),
-					debug.DumpAttr("auth0_connection.sms"),
 				),
 			},
 		},
@@ -386,7 +384,6 @@ func TestAccConnectionEmail(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.email", "options.0.totp.#", "1"),
 					resource.TestCheckResourceAttr("auth0_connection.email", "options.0.totp.0.time_step", "300"),
 					resource.TestCheckResourceAttr("auth0_connection.email", "options.0.totp.0.length", "6"),
-					debug.DumpAttr("auth0_connection.email"),
 				),
 			},
 			{
@@ -395,7 +392,6 @@ func TestAccConnectionEmail(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.email", "options.0.totp.#", "1"),
 					resource.TestCheckResourceAttr("auth0_connection.email", "options.0.totp.0.time_step", "360"),
 					resource.TestCheckResourceAttr("auth0_connection.email", "options.0.totp.0.length", "4"),
-					debug.DumpAttr("auth0_connection.email"),
 				),
 			},
 		},
@@ -468,7 +464,6 @@ func TestAccConnectionSalesforce(t *testing.T) {
 					random.TestCheckResourceAttr("auth0_connection.salesforce_community", "name", "Acceptance-Test-Salesforce-Connection-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_connection.salesforce_community", "strategy", "salesforce-community"),
 					resource.TestCheckResourceAttr("auth0_connection.salesforce_community", "options.0.community_base_url", "https://salesforce.example.com"),
-					debug.DumpAttr("auth0_connection.salesforce_community"),
 				),
 			},
 		},
@@ -512,7 +507,6 @@ func TestAccConnectionGoogleOAuth2(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.google_oauth2", "options.0.scopes.#", "4"),
 					resource.TestCheckResourceAttr("auth0_connection.google_oauth2", "options.0.scopes.881205744", "email"),
 					resource.TestCheckResourceAttr("auth0_connection.google_oauth2", "options.0.scopes.4080487570", "profile"),
-					// debug.DumpAttr("auth0_connection.google_oauth2"),
 				),
 			},
 		},
@@ -605,18 +599,18 @@ func TestAccConnectionConfiguration(t *testing.T) {
 			{
 				Config: random.Template(testAccConnectionConfigurationCreate, rand),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.configuration.%", "2"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.configuration.foo", "xxx"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.configuration.bar", "zzz"),
-					debug.DumpAttr("auth0_connection.my_connection"),
 				),
 			},
 			{
 				Config: random.Template(testAccConnectionConfigurationUpdate, rand),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.configuration.%", "3"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.configuration.foo", "xxx"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.configuration.bar", "yyy"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.configuration.baz", "zzz"),
-					debug.DumpAttr("auth0_connection.my_connection"),
 				),
 			},
 		},

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -7,13 +7,13 @@ import (
 	"gopkg.in/auth0.v4/management"
 )
 
-func flattenConnectionOptions(options interface{}) []interface{} {
+func flattenConnectionOptions(d Data, options interface{}) []interface{} {
 
 	var m interface{}
 
 	switch o := options.(type) {
 	case *management.ConnectionOptions:
-		m = flattenConnectionOptionsAuth0(o)
+		m = flattenConnectionOptionsAuth0(d, o)
 	case *management.ConnectionOptionsGoogleOAuth2:
 		m = flattenConnectionOptionsGoogleOAuth2(o)
 	// case *management.ConnectionOptionsFacebook:
@@ -52,7 +52,7 @@ func flattenConnectionOptionsGitHub(o *management.ConnectionOptionsGitHub) inter
 	}
 }
 
-func flattenConnectionOptionsAuth0(o *management.ConnectionOptions) interface{} {
+func flattenConnectionOptionsAuth0(d Data, o *management.ConnectionOptions) interface{} {
 	return map[string]interface{}{
 		"validation":                     o.Validation,
 		"password_policy":                o.GetPasswordPolicy(),
@@ -66,7 +66,7 @@ func flattenConnectionOptionsAuth0(o *management.ConnectionOptions) interface{} 
 		"disable_signup":                 o.GetDisableSignup(),
 		"requires_username":              o.GetRequiresUsername(),
 		"custom_scripts":                 o.CustomScripts,
-		"configuration":                  o.Configuration,
+		"configuration":                  Map(d, "configuration"), // does not get read back
 	}
 }
 


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #200 

Changes proposed in this pull request:

* When reading back a connection, the `options` `configuration` field is not read back from the API response (which is encrypted) but is read from the state instead.
