### PR TITLE
fix trigger_id from being sent in update payload

### DIFF
--- a/auth0/resource_auth0_hook.go
+++ b/auth0/resource_auth0_hook.go
@@ -11,8 +11,6 @@ import (
 	"gopkg.in/auth0.v4/management"
 )
 
-var hookNameRegexp = regexp.MustCompile("^[^\\s-][\\w -]+[^\\s-]$")
-
 func newHook() *schema.Resource {
 	return &schema.Resource{
 
@@ -26,13 +24,10 @@ func newHook() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringMatch(
-					hookNameRegexp,
-					"Can only contain alphanumeric characters, spaces and '-'. "+
-						"Can neither start nor end with '-' or spaces."),
-				Description: "Name of this hook",
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateHookNameFunc(),
+				Description:  "Name of this hook",
 			},
 			"script": {
 				Type:        schema.TypeString,
@@ -122,7 +117,13 @@ func buildHook(d *schema.ResourceData) *management.Hook {
 	return &management.Hook{
 		Name:      String(d, "name"),
 		Script:    String(d, "script"),
-		TriggerID: String(d, "trigger_id"),
+		TriggerID: String(d, "trigger_id", IsNewResource()),
 		Enabled:   Bool(d, "enabled"),
 	}
+}
+
+func validateHookNameFunc() schema.SchemaValidateFunc {
+	return validation.StringMatch(
+		regexp.MustCompile("^[^\\s-][\\w -]+[^\\s-]$"),
+		"Can only contain alphanumeric characters, spaces and '-'. Can neither start nor end with '-' or spaces.")
 }


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes #209

Changes proposed in this pull request:

* `resource/auth0_hook`: avoid sending `trigger_id` on updates.
* `resource/auth0_hook`: add update tests.

Output from acceptance testing:

```
$ make testacc TESTS=TestAccHook                                         [10:49:29]
==> Checking that code complies with gofmt requirements...
?       github.com/terraform-providers/terraform-provider-auth0 [no test files]
=== RUN   TestAccHook
--- PASS: TestAccHook (3.82s)
PASS
```
