### PR TITLE
Add Apple connection options

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -344,6 +344,18 @@ func newConnection() *schema.Resource {
 							Optional: true,
 						},
 
+						// apple options
+						"team_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Apple Team ID",
+						},
+						"key_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Apple Key ID",
+						},
+
 						// adfs options
 						"adfs_server": {
 							Type:     schema.TypeString,

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -528,6 +528,67 @@ resource "auth0_connection" "google_oauth2" {
 }
 `
 
+func TestAccConnectionApple(t *testing.T) {
+
+	rand := random.String(6)
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: random.Template(testAccConnectionAppleConfig, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_connection.apple", "name", "Acceptance-Test-Apple-{{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_connection.apple", "strategy", "apple"),
+					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.client_id", "client_id"),
+					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.client_secret", "-----BEGIN PRIVATE KEY-----\nMIHBAgEAMA0GCSqGSIb3DQEBAQUABIGsMIGpAgEAAiEA3+luhVHxSJ8cv3VNzQDP\nEL6BPs7FjBq4oro0MWM+QJMCAwEAAQIgWbq6/pRK4/ZXV+ZTSj7zuxsWZuK5i3ET\nfR2TCEkZR3kCEQD2ElqDr/pY5aHA++9HioY9AhEA6PIxC1c/K3gJqu+K+EsfDwIQ\nG5MS8Y7Wzv9skOOqfKnZQQIQdG24vaZZ2GwiyOD5YKiLWQIQYNtrb3j0BWsT4LI+\nN9+l1g==\n-----END PRIVATE KEY-----"),
+					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.team_id", "team_id"),
+					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.key_id", "key_id"),
+				),
+			},
+			{
+				Config: random.Template(testAccConnectionAppleConfigUpdate, rand),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.team_id", "team_id_update"),
+					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.key_id", "key_id_update"),
+				),
+			},
+		},
+	})
+}
+
+const testAccConnectionAppleConfig = `
+
+resource "auth0_connection" "apple" {
+	name = "Acceptance-Test-Apple-{{.random}}"
+	is_domain_connection = false
+	strategy = "apple"
+	options {
+		client_id = "client_id"
+		client_secret = "-----BEGIN PRIVATE KEY-----\nMIHBAgEAMA0GCSqGSIb3DQEBAQUABIGsMIGpAgEAAiEA3+luhVHxSJ8cv3VNzQDP\nEL6BPs7FjBq4oro0MWM+QJMCAwEAAQIgWbq6/pRK4/ZXV+ZTSj7zuxsWZuK5i3ET\nfR2TCEkZR3kCEQD2ElqDr/pY5aHA++9HioY9AhEA6PIxC1c/K3gJqu+K+EsfDwIQ\nG5MS8Y7Wzv9skOOqfKnZQQIQdG24vaZZ2GwiyOD5YKiLWQIQYNtrb3j0BWsT4LI+\nN9+l1g==\n-----END PRIVATE KEY-----"
+		team_id = "team_id"
+		key_id = "key_id"
+	}
+}
+`
+
+const testAccConnectionAppleConfigUpdate = `
+
+resource "auth0_connection" "apple" {
+	name = "Acceptance-Test-Apple-{{.random}}"
+	is_domain_connection = false
+	strategy = "apple"
+	options {
+		client_id = "client_id"
+		client_secret = "-----BEGIN PRIVATE KEY-----\nMIHBAgEAMA0GCSqGSIb3DQEBAQUABIGsMIGpAgEAAiEA3+luhVHxSJ8cv3VNzQDP\nEL6BPs7FjBq4oro0MWM+QJMCAwEAAQIgWbq6/pRK4/ZXV+ZTSj7zuxsWZuK5i3ET\nfR2TCEkZR3kCEQD2ElqDr/pY5aHA++9HioY9AhEA6PIxC1c/K3gJqu+K+EsfDwIQ\nG5MS8Y7Wzv9skOOqfKnZQQIQdG24vaZZ2GwiyOD5YKiLWQIQYNtrb3j0BWsT4LI+\nN9+l1g==\n-----END PRIVATE KEY-----"
+		team_id = "team_id_update"
+		key_id = "key_id_update"
+	}
+}
+`
+
 func TestAccConnectionGitHub(t *testing.T) {
 
 	rand := random.String(6)

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -18,8 +18,8 @@ func flattenConnectionOptions(d Data, options interface{}) []interface{} {
 		m = flattenConnectionOptionsGoogleOAuth2(o)
 	// case *management.ConnectionOptionsFacebook:
 	// 	m = flattenConnectionOptionsFacebook(o)
-	// case *management.ConnectionOptionsApple:
-	// 	m = flattenConnectionOptionsApple(o)
+	case *management.ConnectionOptionsApple:
+		m = flattenConnectionOptionsApple(o)
 	// case *management.ConnectionOptionsLinkedin:
 	// 	m = flattenConnectionOptionsLinkedin(o)
 	case *management.ConnectionOptionsGitHub:
@@ -76,6 +76,16 @@ func flattenConnectionOptionsGoogleOAuth2(o *management.ConnectionOptionsGoogleO
 		"client_secret":     o.GetClientSecret(),
 		"allowed_audiences": o.AllowedAudiences,
 		"scopes":            o.Scopes(),
+	}
+}
+
+func flattenConnectionOptionsApple(o *management.ConnectionOptionsApple) interface{} {
+	return map[string]interface{}{
+		"client_id":     o.GetClientID(),
+		"client_secret": o.GetClientSecret(),
+		"team_id":       o.GetTeamID(),
+		"key_id":        o.GetKeyID(),
+		"scopes":        o.Scopes(),
 	}
 }
 
@@ -172,8 +182,9 @@ func expandConnection(d Data) *management.Connection {
 			c.Options = expandConnectionOptionsAuth0(d)
 		case management.ConnectionStrategyGoogleOAuth2:
 			c.Options = expandConnectionOptionsGoogleOAuth2(d)
+		case management.ConnectionStrategyApple:
+			c.Options = expandConnectionOptionsApple(d)
 		// case management.ConnectionStrategyFacebook
-		// 	management.ConnectionStrategyApple
 		// 	management.ConnectionStrategyLinkedin
 		case management.ConnectionStrategyGitHub:
 			c.Options = expandConnectionOptionsGitHub(d)
@@ -259,6 +270,20 @@ func expandConnectionOptionsGoogleOAuth2(d Data) *management.ConnectionOptionsGo
 		ClientID:         String(d, "client_id"),
 		ClientSecret:     String(d, "client_secret"),
 		AllowedAudiences: Set(d, "allowed_audiences").List(),
+	}
+
+	expandConnectionOptionsScopes(d, o)
+
+	return o
+}
+
+func expandConnectionOptionsApple(d Data) *management.ConnectionOptionsApple {
+
+	o := &management.ConnectionOptionsApple{
+		ClientID:     String(d, "client_id"),
+		ClientSecret: String(d, "client_secret"),
+		TeamID:       String(d, "team_id"),
+		KeyID:        String(d, "key_id"),
 	}
 
 	expandConnectionOptionsScopes(d, o)


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

### Description

Adds the `team_id` and `key_id` options for `Apple` connections.

The `apple` strategy has been introduced in terraform-providers/terraform-provider-auth0#6.

Changes proposed in this pull request:

* Add `team_id` option for `auth0_connection` resources
* Add `key_id` option for `auth0_connection` resources
* Add acceptance test for `Apple` connection

Output from acceptance testing:

```
$ make testacc TESTS=TestAccConnectionApple
==> Checking that code complies with gofmt requirements...
?   	github.com/terraform-providers/terraform-provider-auth0	[no test files]
=== RUN   TestAccConnectionApple
--- PASS: TestAccConnectionApple (1.05s)
PASS
coverage: 11.5% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0	1.076s	coverage: 11.5% of statements
?   	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/debug	[no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/random	0.020s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/validation	0.012s	coverage: 0.0% of statements [no tests to run]
?   	github.com/terraform-providers/terraform-provider-auth0/version	[no test files]
```

The API requires the `client_secret` (app certificate) to be in `PEM` format, otherwise it fails:

```
=== RUN   TestAccConnectionApple
--- FAIL: TestAccConnectionApple (0.45s)
    testing.go:674: Step 0 error: errors during apply:

        Error: 400 Bad Request: options.app_secret must be in PEM format

          on /tmp/tf-test991353821/main.tf line 3:
          (source code not available)
```

I generated the smallest possible (that my local `openssl` client allows) with:

```
$ openssl genpkey -out private.pem -algorithm RSA -pkeyopt rsa_keygen_bits:256
```