### PR TITLE
resource_auth0_tenant: remove TODO

### DIFF
--- a/auth0/resource_auth0_tenant.go
+++ b/auth0/resource_auth0_tenant.go
@@ -280,9 +280,7 @@ func readTenant(d *schema.ResourceData, m interface{}) error {
 	d.Set("sandbox_version", t.SandboxVersion)
 	d.Set("idle_session_lifetime", t.IdleSessionLifetime)
 
-	// TODO: figure out why it is necessary to wrap what is aleady an
-	// []interface{} with another []interface{}.
-	d.Set("enabled_locales", []interface{}{t.EnabledLocales})
+	d.Set("enabled_locales", t.EnabledLocales)
 
 	d.Set("error_page", flattenTenantErrorPage(t.ErrorPage))
 	d.Set("flags", flattenTenantFlags(t.Flags))


### PR DESCRIPTION
This is a tiny, trivial change. I didn't understand why the wrapping was needed either and as far as I can tell locally, it's not. Let's see if CI thinks differently 😉 