### PR TITLE
JWT refresh token configuration

### DIFF
--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -132,6 +132,27 @@ func newClient() *schema.Resource {
 					},
 				},
 			},
+			"refresh_token": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"leeway": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"encryption_key": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -514,6 +535,7 @@ func readClient(d *schema.ResourceData, m interface{}) error {
 	d.Set("form_template", c.FormTemplate)
 	d.Set("token_endpoint_auth_method", c.TokenEndpointAuthMethod)
 	d.Set("jwt_configuration", flattenClientJwtConfiguration(c.JWTConfiguration))
+	d.Set("refresh_token", flattenClientRefreshToken(c.RefreshToken))
 	d.Set("encryption_key", c.EncryptionKey)
 	d.Set("addons", c.Addons)
 	d.Set("client_metadata", c.ClientMetadata)
@@ -588,6 +610,13 @@ func expandClient(d *schema.ResourceData) *management.Client {
 			SecretEncoded:     Bool(d, "secret_encoded", IsNewResource()),
 			Algorithm:         String(d, "alg"),
 			Scopes:            Map(d, "scopes"),
+		}
+	})
+
+	List(d, "refresh_token").Elem(func(d ResourceData) {
+		c.RefreshToken = &management.ClientRefreshToken{
+			Type:   String(d, "type"),
+			Leeway: Int(d, "leeway"),
 		}
 	})
 
@@ -703,6 +732,15 @@ func flattenClientJwtConfiguration(jwt *management.ClientJWTConfiguration) []int
 		m["secret_encoded"] = jwt.SecretEncoded
 		m["scopes"] = jwt.Scopes
 		m["alg"] = jwt.Algorithm
+	}
+	return []interface{}{m}
+}
+
+func flattenClientRefreshToken(refreshToken *management.ClientRefreshToken) []interface{} {
+	m := make(map[string]interface{})
+	if refreshToken != nil {
+		m["type"] = refreshToken.Type
+		m["leeway"] = refreshToken.Leeway
 	}
 	return []interface{}{m}
 }

--- a/auth0/resource_auth0_client_test.go
+++ b/auth0/resource_auth0_client_test.go
@@ -351,3 +351,40 @@ resource "auth0_client" "my_client" {
   }
 }
 `
+
+func TestAccConfigRefreshToken(t *testing.T) {
+
+	rand := random.String(6)
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: random.Template(testAccClientConfigRefreshToken, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_client.my_client", "name", "Acceptance Test - Refresh Token - {{.random}}", rand),
+				),
+			},
+			{
+				Config: random.Template(testAccClientConfigRefreshToken, rand),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_client.my_client", "refresh_token.type", "rotating"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "refresh_token.leeway", "3600"),
+				),
+			},
+		},
+	})
+}
+
+const testAccClientConfigRefreshToken = `
+
+resource "auth0_client" "my_client" {
+  name = "Acceptance Test - JWT Refresh Token - {{.random}}"
+  refresh_token = {
+	type = "rotating"
+	leeway = 3600
+  }
+}
+`


### PR DESCRIPTION
Auth0 has an option to configure the JWT refresh token. I couldn't find such an option in the Auth0 provider, so I attempt to add it. I use Auth0, Terraform and Go for the first time so I'm not sure if everything is correct 😉

### Proposed Changes

* Add JWT Refresh Token configuration

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->