### PR TITLE
Add notes to clarify tenant functionality

### DIFF
--- a/website/docs/r/tenant.html.md
+++ b/website/docs/r/tenant.html.md
@@ -9,8 +9,7 @@ description: |-
 
 With this resource, you can manage Auth0 tenants, including setting logos and support contact information, setting error pages, and configuring default tenant behaviors.
 
-#### Notes:
-Auth0 does not currently support creating or destryoying tenants through their API. This resource can only manage an existing tenant created through the Auth0 dashboard. 
+~> **Note**: Auth0 does not currently support creating tenants through the Management API. Therefore this resource can only manage an existing tenant created through the Auth0 dashboard. 
 
 Auth0 does not currently support adding/removing extensions on tenants through their API. The Auth0 dashboard must be used to add/remove extensions. 
 

--- a/website/docs/r/tenant.html.md
+++ b/website/docs/r/tenant.html.md
@@ -9,6 +9,11 @@ description: |-
 
 With this resource, you can manage Auth0 tenants, including setting logos and support contact information, setting error pages, and configuring default tenant behaviors.
 
+#### Notes:
+Auth0 does not currently support creating or destryoying tenants through their API. This resource can only manage an existing tenant created through the Auth0 dashboard. 
+
+Auth0 does not currently support adding/removing extensions on tenants through their API. The Auth0 dashboard must be used to add/remove extensions. 
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
### Proposed Changes

* Add note to docs about not being able to create/destroy auth0_tenant resource (Auth0 API restriction)
* Add note to docs about not being able to add/remove extensions via TF (Auth0 API restriction)

### Why
It was by chance that I came across this thread while researching a project to implement Auth0 with multiple tenants.

https://community.auth0.com/t/management-api-to-create-a-tenant-and-to-install-and-configure-an-extension/40537

I think it would be really nice to have this information more prominent. I need to create multiple tenants and potentially install some extensions. I was expecting to do all of that with the auth0_tenant resource because typically TF can create and destroy most all resource types. I think not being able to create/destroy the resource is an exception to the norm, and should be called out.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->