### PR TITLE
Force new resource when auth0_rule_config.key has change

### DIFF
--- a/auth0/resource_auth0_rule_config.go
+++ b/auth0/resource_auth0_rule_config.go
@@ -24,6 +24,7 @@ func newRuleConfig() *schema.Resource {
 			"key": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"value": {
 				Type:      schema.TypeString,

--- a/auth0/resource_auth0_rule_config_test.go
+++ b/auth0/resource_auth0_rule_config_test.go
@@ -43,22 +43,54 @@ func TestAccRuleConfig(t *testing.T) {
 			"auth0": Provider(),
 		},
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: random.Template(testAccRuleConfig, rand),
+			{
+				Config: random.Template(testAccRuleConfigCreate, rand),
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_rule_config.foo", "id", "acc_test_{{.random}}", rand),
 					random.TestCheckResourceAttr("auth0_rule_config.foo", "key", "acc_test_{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_rule_config.foo", "value", "bar"),
 				),
 			},
+			{
+				Config: random.Template(testAccRuleConfigUpdateValue, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_rule_config.foo", "id", "acc_test_{{.random}}", rand),
+					random.TestCheckResourceAttr("auth0_rule_config.foo", "key", "acc_test_{{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_rule_config.foo", "value", "foo"),
+				),
+			},
+			{
+				Config: random.Template(testAccRuleConfigUpdateKey, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_rule_config.foo", "id", "acc_test_key_{{.random}}", rand),
+					random.TestCheckResourceAttr("auth0_rule_config.foo", "key", "acc_test_key_{{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_rule_config.foo", "value", "foo"),
+				),
+			},
 		},
 	})
 }
 
-const testAccRuleConfig = `
+const testAccRuleConfigCreate = `
 
 resource "auth0_rule_config" "foo" {
   key = "acc_test_{{.random}}"
   value = "bar"
+}
+`
+
+const testAccRuleConfigUpdateValue = `
+
+resource "auth0_rule_config" "foo" {
+  key = "acc_test_{{.random}}"
+  value = "foo"
+}
+`
+
+const testAccRuleConfigUpdateKey = `
+
+resource "auth0_rule_config" "foo" {
+  key = "acc_test_key_{{.random}}"
+  value = "foo"
 }
 `


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Set `ForceNew: true` for `auth0_rule_config.key`.
* Add more tests to verify the correct behavior.

Fixes #214 

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccRuleConfig                   [14:21:01]
==> Checking that code complies with gofmt requirements...
?       github.com/terraform-providers/terraform-provider-auth0 [no test files]
=== RUN   TestAccRuleConfig
--- PASS: TestAccRuleConfig (2.28s)
PASS
coverage: 7.2% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0   2.596s  coverage: 7.2% of statements
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->