### PR TITLE
correctly transfer username validation to auth0

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -204,8 +204,8 @@ var connectionSchema = map[string]*schema.Schema{
 					Description: "Indicates whether or not to allow user sign-ups to your application",
 				},
 				"requires_username": {
-					Type:     schema.TypeBool,
-					Optional: true,
+					Type:        schema.TypeBool,
+					Optional:    true,
 					Description: "Indicates whether or not the user is required to provide a username in addition to an email address",
 				},
 				"custom_scripts": {
@@ -586,6 +586,39 @@ func connectionSchemaUpgradeV0(state map[string]interface{}, meta interface{}) (
 		state["options"] = []interface{}{m}
 
 		log.Printf("[DEBUG] Schema upgrade: options.strategy_version has been migrated to %d", i)
+	}
+
+	return state, nil
+}
+
+func connectionSchemaUpgradeV1(state map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+
+	o, ok := state["options"]
+	if !ok {
+		return state, nil
+	}
+
+	l, ok := o.([]interface{})
+	if ok && len(l) > 0 {
+
+		m := l[0].(map[string]interface{})
+
+		v, ok := m["validation"]
+		if !ok {
+			return state, nil
+		}
+
+		validation := v.(interface{})
+
+		m["validation"] = []map[string]interface{}{
+			{
+				"username": validation,
+			},
+		}
+
+		state["options"] = []interface{}{m}
+
+		log.Print("[DEBUG] Schema upgrade: options.validation has been migrated to options.validation.user")
 	}
 
 	return state, nil

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -610,9 +610,9 @@ func connectionSchemaUpgradeV1(state map[string]interface{}, meta interface{}) (
 
 		validation := v.(interface{})
 
-		m["validation"] = []map[string]interface{}{
+		m["validation"] = []map[string][]interface{}{
 			{
-				"username": validation,
+				"username": []interface{}{validation},
 			},
 		}
 

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -206,6 +206,7 @@ var connectionSchema = map[string]*schema.Schema{
 				"requires_username": {
 					Type:     schema.TypeBool,
 					Optional: true,
+					Description: "Indicates whether or not the user is required to provide a username in addition to an email address",
 				},
 				"custom_scripts": {
 					Type:        schema.TypeMap,

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -81,8 +81,33 @@ var connectionSchema = map[string]*schema.Schema{
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"validation": {
-					Type:     schema.TypeMap,
-					Elem:     &schema.Schema{Type: schema.TypeString},
+					Type: schema.TypeMap,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"requires_username": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"username": {
+								Optional: true,
+								Type:     schema.TypeMap,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"min": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											ValidateFunc: validation.IntAtLeast(1),
+										},
+										"max": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											ValidateFunc: validation.IntAtLeast(1),
+										},
+									},
+								},
+							},
+						},
+					},
 					Optional: true,
 				},
 				"password_policy": {
@@ -179,11 +204,6 @@ var connectionSchema = map[string]*schema.Schema{
 					Type:        schema.TypeBool,
 					Optional:    true,
 					Description: "Indicates whether or not to allow user sign-ups to your application",
-				},
-				"requires_username": {
-					Type:        schema.TypeBool,
-					Optional:    true,
-					Description: "Indicates whether or not the user is required to provide a username in addition to an email address",
 				},
 				"custom_scripts": {
 					Type:        schema.TypeMap,

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -81,16 +81,14 @@ var connectionSchema = map[string]*schema.Schema{
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"validation": {
-					Type: schema.TypeMap,
+					Type:     schema.TypeList,
+					MaxItems: 1,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
-							"requires_username": {
-								Type:     schema.TypeBool,
-								Optional: true,
-							},
 							"username": {
 								Optional: true,
-								Type:     schema.TypeMap,
+								Type:     schema.TypeList,
+								MaxItems: 1,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
 										"min": {
@@ -204,6 +202,10 @@ var connectionSchema = map[string]*schema.Schema{
 					Type:        schema.TypeBool,
 					Optional:    true,
 					Description: "Indicates whether or not to allow user sign-ups to your application",
+				},
+				"requires_username": {
+					Type:     schema.TypeBool,
+					Optional: true,
 				},
 				"custom_scripts": {
 					Type:        schema.TypeMap,

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -118,10 +118,10 @@ resource "auth0_connection" "my_connection" {
 				max = 40
 			}
 		}
-		requires_username = true
 		enabled_database_customization = false
 		brute_force_protection = true
 		import_mode = false
+		requires_username = true
 		disable_signup = false
 		custom_scripts = {
 			get_user = "myFunction"
@@ -148,11 +148,11 @@ resource "auth0_connection" "my_connection" {
 		password_no_personal_info {
 			enable = true
 		}
-		requires_username = true
 		enabled_database_customization = false
 		brute_force_protection = false
 		import_mode = false
 		disable_signup = false
+		requires_username = true
 		custom_scripts = {
 			get_user = "myFunction"
 		}

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -1015,17 +1015,19 @@ func TestConnectionInstanceStateUpgradeV1(t *testing.T) {
 	for _, tt := range []struct {
 		name               string
 		validation         map[string]string
-		validationExpected []map[string]interface{}
+		validationExpected []map[string][]interface{}
 	}{
 		{
 			name: "Only Min",
 			validation: map[string]string{
 				"min": "5",
 			},
-			validationExpected: []map[string]interface{}{
+			validationExpected: []map[string][]interface{}{
 				{
-					"username": map[string]string{
-						"min": "5",
+					"username": []interface{}{
+						map[string]string{
+							"min": "5",
+						},
 					},
 				},
 			},
@@ -1034,13 +1036,15 @@ func TestConnectionInstanceStateUpgradeV1(t *testing.T) {
 			name: "Min and Max",
 			validation: map[string]string{
 				"min": "5",
-				"max": "10",
+				"max": "5",
 			},
-			validationExpected: []map[string]interface{}{
+			validationExpected: []map[string][]interface{}{
 				{
-					"username": map[string]string{
-						"min": "5",
-						"max": "10",
+					"username": []interface{}{
+						map[string]string{
+							"min": "5",
+							"max": "10",
+						},
 					},
 				},
 			},
@@ -1050,7 +1054,7 @@ func TestConnectionInstanceStateUpgradeV1(t *testing.T) {
 
 			state := map[string]interface{}{
 				"options": []interface{}{
-					map[string]interface{}{"validation": tt.validation},
+					map[string][]interface{}{"validation": []interface{}{tt.validation}},
 				},
 			}
 

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -73,9 +73,9 @@ func TestAccConnection(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.brute_force_protection", "true"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.import_mode", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.disable_signup", "false"),
-					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.requires_username", "true"),
-					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.username.min", "10"),
-					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.username.min", "40"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.requires_username", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.0.username.0.min", "10"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.0.username.0.max", "40"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.custom_scripts.get_user", "myFunction"),
 					resource.TestCheckResourceAttrSet("auth0_connection.my_connection", "options.0.configuration.foo"),
 				),
@@ -113,12 +113,12 @@ resource "auth0_connection" "my_connection" {
 			min_length = 6
 		}
 		validation {
-			requires_username = true
-			username = {
+			username {
 				min = 10
 				max = 40
 			}
 		}
+		requires_username = true
 		enabled_database_customization = false
 		brute_force_protection = true
 		import_mode = false
@@ -148,11 +148,11 @@ resource "auth0_connection" "my_connection" {
 		password_no_personal_info {
 			enable = true
 		}
+		requires_username = true
 		enabled_database_customization = false
 		brute_force_protection = false
 		import_mode = false
 		disable_signup = false
-		requires_username = true
 		custom_scripts = {
 			get_user = "myFunction"
 		}

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -1010,6 +1010,68 @@ func TestConnectionInstanceStateUpgradeV0(t *testing.T) {
 	}
 }
 
+func TestConnectionInstanceStateUpgradeV1(t *testing.T) {
+
+	for _, tt := range []struct {
+		name               string
+		validation         map[string]string
+		validationExpected []map[string]interface{}
+	}{
+		{
+			name: "Only Min",
+			validation: map[string]string{
+				"min": "5",
+			},
+			validationExpected: []map[string]interface{}{
+				{
+					"username": map[string]string{
+						"min": "5",
+					},
+				},
+			},
+		},
+		{
+			name: "Min and Max",
+			validation: map[string]string{
+				"min": "5",
+				"max": "10",
+			},
+			validationExpected: []map[string]interface{}{
+				{
+					"username": map[string]string{
+						"min": "5",
+						"max": "10",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+
+			state := map[string]interface{}{
+				"options": []interface{}{
+					map[string]interface{}{"validation": tt.validation},
+				},
+			}
+
+			actual, err := connectionSchemaUpgradeV1(state, nil)
+			if err != nil {
+				t.Fatalf("error migrating state: %s", err)
+			}
+
+			expected := map[string]interface{}{
+				"options": []interface{}{
+					map[string]interface{}{"validation": tt.validationExpected},
+				},
+			}
+
+			if !reflect.DeepEqual(expected, actual) {
+				t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+			}
+		})
+	}
+}
+
 func TestAccConnectionSAML(t *testing.T) {
 	rand := random.String(6)
 

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -73,7 +73,9 @@ func TestAccConnection(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.brute_force_protection", "true"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.import_mode", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.disable_signup", "false"),
-					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.requires_username", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.requires_username", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.username.min", "10"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.username.min", "40"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.custom_scripts.get_user", "myFunction"),
 					resource.TestCheckResourceAttrSet("auth0_connection.my_connection", "options.0.configuration.foo"),
 				),
@@ -110,11 +112,17 @@ resource "auth0_connection" "my_connection" {
 		password_complexity_options {
 			min_length = 6
 		}
+		validation {
+			requires_username = true
+			username = {
+				min = 10
+				max = 40
+			}
+		}
 		enabled_database_customization = false
 		brute_force_protection = true
 		import_mode = false
 		disable_signup = false
-		requires_username = true
 		custom_scripts = {
 			get_user = "myFunction"
 		}

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -66,6 +66,7 @@ func flattenConnectionOptionsAuth0(d ResourceData, o *management.ConnectionOptio
 		"brute_force_protection":         o.GetBruteForceProtection(),
 		"import_mode":                    o.GetImportMode(),
 		"disable_signup":                 o.GetDisableSignup(),
+		"requires_username":              o.GetRequiresUsername(),
 		"custom_scripts":                 o.CustomScripts,
 		"configuration":                  Map(d, "configuration"), // does not get read back
 	}

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -66,7 +66,6 @@ func flattenConnectionOptionsAuth0(d ResourceData, o *management.ConnectionOptio
 		"brute_force_protection":         o.GetBruteForceProtection(),
 		"import_mode":                    o.GetImportMode(),
 		"disable_signup":                 o.GetDisableSignup(),
-		"requires_username":              o.GetRequiresUsername(),
 		"custom_scripts":                 o.CustomScripts,
 		"configuration":                  Map(d, "configuration"), // does not get read back
 	}
@@ -291,9 +290,18 @@ func expandConnectionOptionsGitHub(d ResourceData) *management.ConnectionOptions
 func expandConnectionOptionsAuth0(d ResourceData) *management.ConnectionOptions {
 
 	o := &management.ConnectionOptions{
-		Validation:     Map(d, "validation"),
 		PasswordPolicy: String(d, "password_policy"),
 	}
+
+	List(d, "validation").Elem(func(d ResourceData) {
+		o.Validation = make(map[string]interface{})
+		List(d, "username").Elem(func(d ResourceData) {
+			usernameValidation := make(map[string]*int)
+			usernameValidation["min"] = Int(d, "min")
+			usernameValidation["max"] = Int(d, "max")
+			o.Validation["username"] = usernameValidation
+		})
+	})
 
 	List(d, "password_history").Elem(func(d ResourceData) {
 		o.PasswordHistory = make(map[string]interface{})


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Correctly sending username validation to Auth0

Fixes #238

#### Acceptance Test Output

```
make testacc TESTS=TestAccConnection
==> Checking that code complies with gofmt requirements...
?   	github.com/terraform-providers/terraform-provider-auth0	[no test files]
=== RUN   TestAccConnection
--- PASS: TestAccConnection (2.01s)
=== RUN   TestAccConnectionAD
--- PASS: TestAccConnectionAD (0.85s)
=== RUN   TestAccConnectionAzureAD
--- PASS: TestAccConnectionAzureAD (7.16s)
=== RUN   TestAccConnectionOIDC
--- PASS: TestAccConnectionOIDC (1.80s)
=== RUN   TestAccConnectionWithEnbledClients
--- PASS: TestAccConnectionWithEnbledClients (19.63s)
=== RUN   TestAccConnectionSMS
--- PASS: TestAccConnectionSMS (0.90s)
=== RUN   TestAccConnectionEmail
--- PASS: TestAccConnectionEmail (6.55s)
=== RUN   TestAccConnectionSalesforce
--- PASS: TestAccConnectionSalesforce (0.90s)
=== RUN   TestAccConnectionGoogleOAuth2
--- PASS: TestAccConnectionGoogleOAuth2 (0.83s)
=== RUN   TestAccConnectionFacebook
--- PASS: TestAccConnectionFacebook (7.67s)
=== RUN   TestAccConnectionApple
--- PASS: TestAccConnectionApple (1.73s)
=== RUN   TestAccConnectionLinkedin
--- PASS: TestAccConnectionLinkedin (7.84s)
=== RUN   TestAccConnectionGitHub
--- PASS: TestAccConnectionGitHub (0.97s)
=== RUN   TestAccConnectionConfiguration
--- PASS: TestAccConnectionConfiguration (7.83s)
=== RUN   TestAccConnectionSAML
--- PASS: TestAccConnectionSAML (7.75s)
PASS
coverage: 27.3% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0	74.726s	coverage: 27.3% of statements
?   	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/debug	[no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/random	0.262s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/validation	0.288s	coverage: 0.0% of statements [no tests to run]
?   	github.com/terraform-providers/terraform-provider-auth0/version	[no test files]
...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

#### Note: Contains breaking changes:
- Moved `options.requires_username` to `options.validation` 
- Changed Data Structure of `options.validation`
