### PR TITLE
Support validation for the length of auth0_client description length

### DIFF
--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -30,8 +30,9 @@ func newClient() *schema.Resource {
 				Required: true,
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 140),
 			},
 			"client_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Introduce `ValidateFunc` to the `description` field of `auth0_client` resource.

Currently, since we don't have a validation for this field, users can run into issue when they try to create/update an `auth0_client` where the `description` field is too long. The error from Auth0 is:

```
Error: 400 Bad Request: Payload validation error: 'String is too long (xxx chars), maximum 140' on property description (Free text description of the purpose of the Client. (Max character length: <code>140</code>)).
```

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccXXX

==> Checking that code complies with gofmt requirements...
?   	github.com/terraform-providers/terraform-provider-auth0	[no test files]
=== RUN   TestAccClientGrant
--- PASS: TestAccClientGrant (47.05s)
=== RUN   TestAccClient
--- PASS: TestAccClient (2.65s)
=== RUN   TestAccClientZeroValueCheck
--- PASS: TestAccClientZeroValueCheck (6.19s)
=== RUN   TestAccClientRotateSecret
--- PASS: TestAccClientRotateSecret (4.48s)
=== RUN   TestAccClientInitiateLoginUri
--- PASS: TestAccClientInitiateLoginUri (0.03s)
=== RUN   TestAccClientJwtScopes
--- PASS: TestAccClientJwtScopes (4.48s)
PASS
coverage: 25.3% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0	64.987s	coverage: 25.3% of statements
?   	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/debug	[no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/random	0.072s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/terraform-providers/terraform-provider-auth0/auth0/internal/validation	0.020s	coverage: 0.0% of statements [no tests to run]
?   	github.com/terraform-providers/terraform-provider-auth0/version	[no test files]
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->