### PR TITLE
auth0/structure_auth0_connection.go: Properly expand all SAML options

### DIFF
--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -512,6 +512,7 @@ func expandConnectionOptionsOIDC(d ResourceData) *management.ConnectionOptionsOI
 
 func expandConnectionOptionsSAML(d ResourceData) *management.ConnectionOptionsSAML {
 	o := &management.ConnectionOptionsSAML{
+		Debug:              Bool(d, "debug"),
 		SigningCert:        String(d, "signing_cert"),
 		ProtocolBinding:    String(d, "protocol_binding"),
 		TenantDomain:       String(d, "tenant_domain"),
@@ -524,7 +525,7 @@ func expandConnectionOptionsSAML(d ResourceData) *management.ConnectionOptionsSA
 		SignSAMLRequest:    Bool(d, "sign_saml_request"),
 	}
 
-	Set(d, "idp_initiated").Elem(func(d ResourceData) {
+	List(d, "idp_initiated").Elem(func(d ResourceData) {
 		o.IdpInitiated = &management.ConnectionOptionsSAMLIdpInitiated{
 			ClientID:             String(d, "client_id"),
 			ClientProtocol:       String(d, "client_protocol"),


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

Properly expands all SAML options from Terraform config into the correct Auth0 data structures for sending to the Auth0 API. 

Currently the `debug` flag isn't sent at all (causing it to turn off if enabled by hand in the management console) and the wrong type conversion was made on the `idp_initiated` option causing it to not be sent when configured (and also destroying hand edited configuration on Auth0's side).

#### Acceptance Test Output
```
$ AUTH0_DOMAIN=foo.auth0.com AUTH0_CLIENT_ID=client_id AUTH0_CLIENT_SECRET=client_secret make testacc TESTS=TestAccConnectionSAML
==> Checking that code complies with gofmt requirements...
?       github.com/terraform-providers/terraform-provider-auth0 [no test files]
=== RUN   TestAccConnectionSAML
    TestAccConnectionSAML: testing.go:683: Step 0 error: errors during plan:

        Error: oauth2: cannot fetch token: 401 Unauthorized
        Response: {"error":"access_denied","error_description":"Unauthorized"}

          on <empty> line 0:
          (source code not available)


    TestAccConnectionSAML: testing.go:744: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during apply: oauth2: cannot fetch token: 401 Unauthorized
        Response: {"error":"access_denied","error_description":"Unauthorized"}

        State: <no state>
--- FAIL: TestAccConnectionSAML (0.40s)
FAIL
coverage: 4.2% of statements
FAIL    github.com/terraform-providers/terraform-provider-auth0/auth0   0.414s
?       github.com/terraform-providers/terraform-provider-auth0/auth0/internal/debug    [no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0/internal/random   0.014s  coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0/internal/validation       0.002s  coverage: 0.0% of statements [no tests to run]
?       github.com/terraform-providers/terraform-provider-auth0/version [no test files]
FAIL
make: *** [GNUmakefile:26: testacc] Error 1
```

Unfortunately I don't have a test Auth0 account to run the tests against :(.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->