### PR TITLE
Add "HookSecrets" support through "auth0_hook"

### DIFF
--- a/auth0/resource_auth0_hook.go
+++ b/auth0/resource_auth0_hook.go
@@ -50,9 +50,16 @@ func newHook() *schema.Resource {
 					"post-user-registration, post-change-password" +
 					", or send-phone-message",
 			},
+			"secrets": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "The secrets associated with the hook",
+				Elem:        schema.TypeString,
+			},
 			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 				Description: "Whether the hook is enabled, or disabled",
 			},
 		},
@@ -66,6 +73,9 @@ func createHook(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	d.SetId(auth0.StringValue(c.ID))
+	if err := upsertHookSecrets(d, m); err != nil {
+		return err
+	}
 	return readHook(d, m)
 }
 
@@ -96,7 +106,30 @@ func updateHook(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
+	if err = upsertHookSecrets(d, m); err != nil {
+		return err
+	}
 	return readHook(d, m)
+}
+
+func upsertHookSecrets(d *schema.ResourceData, m interface{}) error {
+	if d.IsNewResource() || d.HasChange("secrets") {
+		secrets := Map(d, "secrets")
+		api := m.(*management.Management)
+		hookSecrets := toHookSecrets(secrets)
+		return api.Hook.ReplaceSecrets(d.Id(), hookSecrets)
+	}
+	return nil
+}
+
+func toHookSecrets(val map[string]interface{}) management.HookSecrets {
+	hookSecrets := management.HookSecrets{}
+	for key, value := range val {
+		if strVal, ok := value.(string); ok {
+			hookSecrets[key] = strVal
+		}
+	}
+	return hookSecrets
 }
 
 func deleteHook(d *schema.ResourceData, m interface{}) error {

--- a/auth0/resource_auth0_hook_test.go
+++ b/auth0/resource_auth0_hook_test.go
@@ -1,6 +1,7 @@
 package auth0
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -23,15 +24,6 @@ func TestAccHook(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_hook.my_hook", "enabled", "true"),
 				),
 			},
-			{
-				Config: testAccHookUpdate,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("auth0_hook.my_hook", "name", "pre-user-reg-hook"),
-					resource.TestCheckResourceAttr("auth0_hook.my_hook", "script", "function (user, context, callback) { console.log(user); callback(null, { user }); }"),
-					resource.TestCheckResourceAttr("auth0_hook.my_hook", "trigger_id", "pre-user-registration"),
-					resource.TestCheckResourceAttr("auth0_hook.my_hook", "enabled", "false"),
-				),
-			},
 		},
 	})
 }
@@ -40,21 +32,84 @@ const testAccHookCreate = `
 
 resource "auth0_hook" "my_hook" {
   name = "pre-user-reg-hook"
-  trigger_id = "pre-user-registration"
   script = "function (user, context, callback) { callback(null, { user }); }"
+  trigger_id = "pre-user-registration"
   enabled = true
 }
 `
 
-const testAccHookUpdate = `
+func TestAccHookSecrets(t *testing.T) {
 
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHookSecrets("alpha"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "name", "pre-user-reg-hook"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "script", "function (user, context, callback) { callback(null, { user }); }"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "trigger_id", "pre-user-registration"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "enabled", "true"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "secrets.foo", "alpha"),
+					resource.TestCheckNoResourceAttr("auth0_hook.my_hook", "secrets.bar"),
+				),
+			},
+			{
+				Config: testAccHookSecrets2("gamma", "kappa"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "name", "pre-user-reg-hook"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "script", "function (user, context, callback) { callback(null, { user }); }"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "trigger_id", "pre-user-registration"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "enabled", "true"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "secrets.foo", "gamma"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "secrets.bar", "kappa"),
+				),
+			},
+			{
+				Config: testAccHookSecrets("delta"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "name", "pre-user-reg-hook"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "script", "function (user, context, callback) { callback(null, { user }); }"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "trigger_id", "pre-user-registration"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "enabled", "true"),
+					resource.TestCheckResourceAttr("auth0_hook.my_hook", "secrets.foo", "delta"),
+					resource.TestCheckNoResourceAttr("auth0_hook.my_hook", "secrets.bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccHookSecrets(fooValue string) string {
+	return fmt.Sprintf(`
 resource "auth0_hook" "my_hook" {
   name = "pre-user-reg-hook"
+  script = "function (user, context, callback) { callback(null, { user }); }"
   trigger_id = "pre-user-registration"
-  script = "function (user, context, callback) { console.log(user); callback(null, { user }); }"
-  enabled = false
+  enabled = true
+  secrets = {
+    foo = "%s"
+  }
 }
-`
+`, fooValue)
+}
+
+func testAccHookSecrets2(fooValue string, barValue string) string {
+	return fmt.Sprintf(`
+resource "auth0_hook" "my_hook" {
+  name = "pre-user-reg-hook"
+  script = "function (user, context, callback) { callback(null, { user }); }"
+  trigger_id = "pre-user-registration"
+  enabled = true
+  secrets = {
+    foo = "%s"
+    bar = "%s"
+  }
+}
+`, fooValue, barValue)
+}
 
 func TestHookNameRegexp(t *testing.T) {
 	for name, valid := range map[string]bool{


### PR DESCRIPTION
### Proposed Changes

* Add support for "HookSecrets" based on feedback from #205 

Fixes #205

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccHookSecrets
==> Checking that code complies with gofmt requirements...
?       github.com/terraform-providers/terraform-provider-auth0 [no test files]
=== RUN   TestAccHookSecrets
--- PASS: TestAccHookSecrets (8.46s)
PASS
coverage: 11.5% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0   9.361s  coverage: 11.5% of statements
?       github.com/terraform-providers/terraform-provider-auth0/auth0/internal/debug    [no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0/internal/random   0.492s  coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/terraform-providers/terraform-provider-auth0/auth0/internal/validation       0.198s  coverage: 0.0% of statements [no tests to run]
?       github.com/terraform-providers/terraform-provider-auth0/version [no test files]
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request