### PR TITLE
Add signing_keys to client resource

### DIFF
--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -539,6 +539,7 @@ func readClient(d *schema.ResourceData, m interface{}) error {
 	d.Set("allowed_logout_urls", c.AllowedLogoutURLs)
 	d.Set("allowed_origins", c.AllowedOrigins)
 	d.Set("grant_types", c.GrantTypes)
+    d.Set("signing_keys", c.SigningKeys)
 	d.Set("web_origins", c.WebOrigins)
 	d.Set("sso", c.SSO)
 	d.Set("sso_disabled", c.SSODisabled)


### PR DESCRIPTION
Reopening [this PR](https://github.com/alexkappa/terraform-provider-auth0/pull/220) as we need it as well - seems it was closed without being considered. Signing keys are useful as an output of a configured client.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->