### PR TITLE
Add Auth0 sponsorship message to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Auth0 Terraform Provider
 [![Test Coverage](https://api.codeclimate.com/v1/badges/9c49c10286123b716c79/test_coverage)](https://codeclimate.com/github/alexkappa/terraform-provider-auth0/test_coverage)
 [![Gitter](https://badges.gitter.im/terraform-provider-auth0/community.svg)](https://gitter.im/terraform-provider-auth0/community)
 
+Sponsor
+-------
+
+| <img width="50" src="https://cdn.auth0.com/blog/open-source-sponsorship.png"> | <div style="text-align: left;">If you want to quickly implement a secure authentication flow with Terraform, create a free plan at [auth0.com/developers](https://auth0.com/developers?utm_source=GHsponsor&utm_medium=GHsponsor&utm_campaign=terraform_auth0_provider&utm_content=auth).</div> |
+| :---------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
 Requirements
 ------------


### PR DESCRIPTION
### Proposed Changes

Thanks again for your hard work on this Terraform provider, as a token of appreciation we decided to sponsor this project! This pull request adds the sponsorship message to the readme as agreed upon.

Keep up the good work!

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request