### PR TITLE
Fix connection display name

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -708,6 +708,7 @@ func readConnection(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(auth0.StringValue(c.ID))
 	d.Set("name", c.Name)
+	d.Set("display_name", c.Name)
 	d.Set("is_domain_connection", c.IsDomainConnection)
 	d.Set("strategy", c.Strategy)
 	d.Set("options", flattenConnectionOptions(d, c.Options))

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -708,7 +708,7 @@ func readConnection(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId(auth0.StringValue(c.ID))
 	d.Set("name", c.Name)
-	d.Set("display_name", c.Name)
+	d.Set("display_name", c.DisplayName)
 	d.Set("is_domain_connection", c.IsDomainConnection)
 	d.Set("strategy", c.Strategy)
 	d.Set("options", flattenConnectionOptions(d, c.Options))

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -1272,6 +1272,7 @@ func TestAccConnectionSAML(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_connection.my_connection", "name", "Acceptance-Test-SAML-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "strategy", "samlp"),
+					random.TestCheckResourceAttr("auth0_connection.my_connection", "display_name", "Acceptance-Test-SAML-{{.random}}", rand),
 				),
 			},
 			{
@@ -1288,6 +1289,7 @@ func TestAccConnectionSAML(t *testing.T) {
 const testConnectionSAMLConfigCreate = `
 resource "auth0_connection" "my_connection" {
 	name = "Acceptance-Test-SAML-{{.random}}"
+	display_name = "Acceptance-Test-SAML-{{.random}}"
 	strategy = "samlp"
 	options {
 		signing_cert = <<EOF
@@ -1341,6 +1343,7 @@ EOF
 const testConnectionSAMLConfigUpdate = `
 resource "auth0_connection" "my_connection" {
 	name = "Acceptance-Test-SAML-{{.random}}"
+	display_name = "Acceptance-Test-SAML-{{.random}}"
 	strategy = "samlp"
 	options {
 		signing_cert = <<EOF

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -265,6 +265,7 @@ func expandConnection(d ResourceData) *management.Connection {
 
 	c := &management.Connection{
 		Name:               String(d, "name", IsNewResource()),
+		DisplayName:        String(d, "display_name"),
 		Strategy:           String(d, "strategy", IsNewResource()),
 		IsDomainConnection: Bool(d, "is_domain_connection"),
 		EnabledClients:     Set(d, "enabled_clients").List(),


### PR DESCRIPTION
### Proposed Changes

* Add `display_name` to `auth0_connection` resource.

Fixes #288

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccConnectionSAML                                                                                                         [18:52:07]
==> Checking that code complies with gofmt requirements...
?       github.com/alexkappa/terraform-provider-auth0   [no test files]
=== RUN   TestAccConnectionSAML
--- PASS: TestAccConnectionSAML (2.08s)
PASS
coverage: 10.6% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0     2.377s  coverage: 10.6% of statements
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->