### PR TITLE
Add new identifier_first field to prompt

### DIFF
--- a/auth0/resource_auth0_prompt.go
+++ b/auth0/resource_auth0_prompt.go
@@ -31,6 +31,10 @@ func newPrompt() *schema.Resource {
 					"new", "classic",
 				}, false),
 			},
+			"identifier_first": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -53,6 +57,7 @@ func readPrompt(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	d.Set("universal_login_experience", p.UniversalLoginExperience)
+	d.Set("identifier_first", p.IdentifierFirst)
 	return nil
 }
 
@@ -74,5 +79,6 @@ func deletePrompt(d *schema.ResourceData, m interface{}) error {
 func buildPrompt(d *schema.ResourceData) *management.Prompt {
 	return &management.Prompt{
 		UniversalLoginExperience: auth0.StringValue(String(d, "universal_login_experience")),
+		IdentifierFirst:          Bool(d, "identifier_first"),
 	}
 }

--- a/auth0/resource_auth0_prompt_test.go
+++ b/auth0/resource_auth0_prompt_test.go
@@ -17,13 +17,15 @@ func TestAccPrompt(t *testing.T) {
 			{
 				Config: testAccPromptCreate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("auth0_prompt.prompt", "universal_login_experience", "new"),
+					resource.TestCheckResourceAttr("auth0_prompt.prompt", "universal_login_experience", "classic"),
+					resource.TestCheckResourceAttr("auth0_prompt.prompt", "identifier_first", "false"),
 				),
 			},
 			{
 				Config: testAccPromptUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("auth0_prompt.prompt", "universal_login_experience", "classic"),
+					resource.TestCheckResourceAttr("auth0_prompt.prompt", "universal_login_experience", "new"),
+					resource.TestCheckResourceAttr("auth0_prompt.prompt", "identifier_first", "true"),
 				),
 			},
 		},
@@ -33,13 +35,14 @@ func TestAccPrompt(t *testing.T) {
 const testAccPromptCreate = `
 
 resource "auth0_prompt" "prompt" {
-  universal_login_experience = "new"
+  universal_login_experience = "classic"
 }
 `
 
 const testAccPromptUpdate = `
 
 resource "auth0_prompt" "prompt" {
-  universal_login_experience = "classic"
+  universal_login_experience = "new"
+  identifier_first = true
 }
 `


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

Pending https://github.com/go-auth0/auth0/pull/187 (will add test output and update here when that is merged/released)

Adds the new identifier_first argument to prompts. I will update the terraform provider as well once this lands and is tagged.

https://support.auth0.com/notifications/5fff0ab3f28427000a77941e

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccXXX

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->