### PR TITLE
Adds set_user_root_attributes to connections

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -408,6 +408,16 @@ var connectionSchema = map[string]*schema.Schema{
 					},
 				},
 
+				"set_user_root_attributes": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"on_each_login", "on_first_login",
+					}, false),
+					Description: "Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using an external IdP. Possible values are 'on_each_login' (default value, it configures the connection to automatically update the root attributes from the external IdP with each user login. When this setting is used, root attributes cannot be independently updated), 'on_first_login' (configures the connection to only set the root attributes on first login, allowing them to be independently updated thereafter)",
+				},
+
 				// apple options
 				"team_id": {
 					Type:        schema.TypeString,

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -76,6 +76,7 @@ func TestAccConnection(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.import_mode", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.disable_signup", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.requires_username", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.set_user_root_attributes", "on_each_login"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.0.username.0.min", "10"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.0.username.0.max", "40"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.custom_scripts.get_user", "myFunction"),
@@ -89,6 +90,7 @@ func TestAccConnection(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.brute_force_protection", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.mfa.0.return_enroll_settings", "false"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.set_user_root_attributes", "on_first_login"),
 				),
 			},
 		},
@@ -138,6 +140,7 @@ resource "auth0_connection" "my_connection" {
 			active                 = true
 			return_enroll_settings = true
 		}
+		set_user_root_attributes = "on_each_login"
 	}
 }
 `
@@ -172,6 +175,7 @@ resource "auth0_connection" "my_connection" {
 			active                 = true
 			return_enroll_settings = false
 		}
+		set_user_root_attributes = "on_first_login"
 	}
 }
 `
@@ -197,6 +201,7 @@ func TestAccConnectionAD(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.ad", "options.0.ips.2555711295", "192.168.1.1"),
 					resource.TestCheckResourceAttr("auth0_connection.ad", "options.0.domain_aliases.3506632655", "example.com"),
 					resource.TestCheckResourceAttr("auth0_connection.ad", "options.0.domain_aliases.3154807651", "api.example.com"),
+					resource.TestCheckResourceAttr("auth0_connection.ad", "options.0.set_user_root_attributes", "on_each_login"),
 				),
 			},
 		},
@@ -215,6 +220,7 @@ resource "auth0_connection" "ad" {
 			"api.example.com"
 		]
 		ips = [ "192.168.1.1", "192.168.1.2" ]
+		set_user_root_attributes = "on_each_login"
 	}
 }
 `
@@ -244,6 +250,7 @@ func TestAccConnectionAzureAD(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.scopes.370042894", "basic_profile"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.scopes.1268340351", "ext_profile"),
 					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.scopes.541325467", "ext_groups"),
+					resource.TestCheckResourceAttr("auth0_connection.azure_ad", "options.0.set_user_root_attributes", "on_each_login"),
 				),
 			},
 		},
@@ -273,6 +280,7 @@ resource "auth0_connection" "azure_ad" {
 			"ext_groups",
 			"ext_profile"
 		]
+		set_user_root_attributes = "on_each_login"
 	}
 }
 `
@@ -307,6 +315,7 @@ func TestAccConnectionOIDC(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.scopes.2517049750", "openid"),
 					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.scopes.4080487570", "profile"),
 					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.scopes.881205744", "email"),
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.set_user_root_attributes", "on_each_login"),
 				),
 			},
 			{
@@ -326,6 +335,7 @@ func TestAccConnectionOIDC(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.scopes.#", "2"),
 					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.scopes.2517049750", "openid"),
 					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.scopes.881205744", "email"),
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.set_user_root_attributes", "on_first_login"),
 				),
 			},
 		},
@@ -352,6 +362,7 @@ resource "auth0_connection" "oidc" {
 		userinfo_endpoint      = "https://api.login.yahoo.com/openid/v1/userinfo"
 		authorization_endpoint = "https://api.login.yahoo.com/oauth2/request_auth"
 		scopes = [ "openid", "email", "profile" ]
+		set_user_root_attributes = "on_each_login"
 	}
 }
 `
@@ -375,6 +386,7 @@ resource "auth0_connection" "oidc" {
 		userinfo_endpoint      = "https://api.paypal.com/v1/oauth2/token/userinfo"
 		authorization_endpoint = "https://www.paypal.com/signin/authorize"
 		scopes = [ "openid", "email" ]
+		set_user_root_attributes = "on_first_login"
 	}
 }
 `
@@ -402,6 +414,7 @@ func TestAccConnectionOAuth2(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.scopes.4080487570", "profile"),
 					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.scopes.881205744", "email"),
 					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.scripts.fetchUserProfile", "function( { return callback(null) }"),
+					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.set_user_root_attributes", "on_each_login"),
 				),
 			},
 			{
@@ -415,6 +428,7 @@ func TestAccConnectionOAuth2(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.scopes.2517049750", "openid"),
 					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.scopes.881205744", "email"),
 					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.scripts.fetchUserProfile", "function( { return callback(null) }"),
+					resource.TestCheckResourceAttr("auth0_connection.oauth2", "options.0.set_user_root_attributes", "on_first_login"),
 				),
 			},
 		},
@@ -433,6 +447,7 @@ resource "auth0_connection" "oauth2" {
 		token_endpoint         = "https://api.login.yahoo.com/oauth2/get_token"
 		authorization_endpoint = "https://api.login.yahoo.com/oauth2/request_auth"
 		scopes = [ "openid", "email", "profile" ]
+		set_user_root_attributes = "on_each_login"
 		scripts = {
 			fetchUserProfile= "function( { return callback(null) }"
 		}
@@ -452,6 +467,7 @@ resource "auth0_connection" "oauth2" {
 		token_endpoint         = "https://api.paypal.com/v1/oauth2/token"
 		authorization_endpoint = "https://www.paypal.com/signin/authorize"
 		scopes = [ "openid", "email" ]
+		set_user_root_attributes = "on_first_login"
 		scripts = {
 			fetchUserProfile= "function( { return callback(null) }"
 		}
@@ -711,6 +727,7 @@ func TestAccConnectionGoogleOAuth2(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.google_oauth2", "options.0.scopes.#", "4"),
 					resource.TestCheckResourceAttr("auth0_connection.google_oauth2", "options.0.scopes.881205744", "email"),
 					resource.TestCheckResourceAttr("auth0_connection.google_oauth2", "options.0.scopes.4080487570", "profile"),
+					resource.TestCheckResourceAttr("auth0_connection.google_oauth2", "options.0.set_user_root_attributes", "on_each_login"),
 				),
 			},
 		},
@@ -728,6 +745,7 @@ resource "auth0_connection" "google_oauth2" {
 		client_secret = ""
 		allowed_audiences = [ "example.com", "api.example.com" ]
 		scopes = [ "email", "profile", "gmail", "youtube" ]
+		set_user_root_attributes = "on_each_login"
 	}
 }
 `
@@ -817,6 +835,7 @@ func TestAccConnectionApple(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.scopes.#", "2"),
 					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.scopes.2318696674", "name"),
 					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.scopes.881205744", "email"),
+					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.set_user_root_attributes", "on_each_login"),
 				),
 			},
 			{
@@ -826,6 +845,7 @@ func TestAccConnectionApple(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.key_id", "key_id_update"),
 					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.scopes.#", "1"),
 					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.scopes.881205744", "email"),
+					resource.TestCheckResourceAttr("auth0_connection.apple", "options.0.set_user_root_attributes", "on_first_login"),
 				),
 			},
 		},
@@ -844,6 +864,7 @@ resource "auth0_connection" "apple" {
 		team_id = "team_id"
 		key_id = "key_id"
 		scopes = ["email", "name"]
+		set_user_root_attributes = "on_each_login"
 	}
 }
 `
@@ -860,6 +881,7 @@ resource "auth0_connection" "apple" {
 		team_id = "team_id_update"
 		key_id = "key_id_update"
 		scopes = ["email"]
+		set_user_root_attributes = "on_first_login"
 	}
 }
 `

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -72,62 +72,69 @@ func flattenConnectionOptionsAuth0(d ResourceData, o *management.ConnectionOptio
 		"custom_scripts":                 o.CustomScripts,
 		"mfa":                            o.MFA,
 		"configuration":                  Map(d, "configuration"), // does not get read back
+		"set_user_root_attributes":       o.GetSetUserAttributes(),
 	}
 }
 
 func flattenConnectionOptionsGoogleOAuth2(o *management.ConnectionOptionsGoogleOAuth2) interface{} {
 	return map[string]interface{}{
-		"client_id":         o.GetClientID(),
-		"client_secret":     o.GetClientSecret(),
-		"allowed_audiences": o.AllowedAudiences,
-		"scopes":            o.Scopes(),
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"allowed_audiences":        o.AllowedAudiences,
+		"scopes":                   o.Scopes(),
+		"set_user_root_attributes": o.GetSetUserAttributes(),
 	}
 }
 
 func flattenConnectionOptionsOAuth2(o *management.ConnectionOptionsOAuth2) interface{} {
 	return map[string]interface{}{
-		"client_id":              o.GetClientID(),
-		"client_secret":          o.GetClientSecret(),
-		"scopes":                 o.Scopes(),
-		"token_endpoint":         o.GetTokenURL(),
-		"authorization_endpoint": o.GetAuthorizationURL(),
-		"scripts":                o.Scripts,
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"scopes":                   o.Scopes(),
+		"token_endpoint":           o.GetTokenURL(),
+		"authorization_endpoint":   o.GetAuthorizationURL(),
+		"scripts":                  o.Scripts,
+		"set_user_root_attributes": o.GetSetUserAttributes(),
 	}
 }
 
 func flattenConnectionOptionsFacebook(o *management.ConnectionOptionsFacebook) interface{} {
 	return map[string]interface{}{
-		"client_id":     o.GetClientID(),
-		"client_secret": o.GetClientSecret(),
-		"scopes":        o.Scopes(),
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"scopes":                   o.Scopes(),
+		"set_user_root_attributes": o.GetSetUserAttributes(),
 	}
 }
 
 func flattenConnectionOptionsApple(o *management.ConnectionOptionsApple) interface{} {
 	return map[string]interface{}{
-		"client_id":     o.GetClientID(),
-		"client_secret": o.GetClientSecret(),
-		"team_id":       o.GetTeamID(),
-		"key_id":        o.GetKeyID(),
-		"scopes":        o.Scopes(),
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"team_id":                  o.GetTeamID(),
+		"key_id":                   o.GetKeyID(),
+		"scopes":                   o.Scopes(),
+		"set_user_root_attributes": o.GetSetUserAttributes(),
 	}
 }
 
 func flattenConnectionOptionsLinkedin(o *management.ConnectionOptionsLinkedin) interface{} {
 	return map[string]interface{}{
-		"client_id":        o.GetClientID(),
-		"client_secret":    o.GetClientSecret(),
-		"strategy_version": o.GetStrategyVersion(),
-		"scopes":           o.Scopes(),
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"strategy_version":         o.GetStrategyVersion(),
+		"scopes":                   o.Scopes(),
+		"set_user_root_attributes": o.GetSetUserAttributes(),
 	}
 }
 
 func flattenConnectionOptionsSalesforce(o *management.ConnectionOptionsSalesforce) interface{} {
 	return map[string]interface{}{
-		"client_id":          o.GetClientID(),
-		"client_secret":      o.GetClientSecret(),
-		"community_base_url": o.GetCommunityBaseURL(),
-		"scopes":             o.Scopes(),
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"community_base_url":       o.GetCommunityBaseURL(),
+		"scopes":                   o.Scopes(),
+		"set_user_root_attributes": o.GetSetUserAttributes(),
 	}
 }
 
@@ -181,38 +188,41 @@ func flattenConnectionOptionsEmail(o *management.ConnectionOptionsEmail) interfa
 			"time_step": o.OTP.GetTimeStep(),
 			"length":    o.OTP.GetLength(),
 		},
+		"set_user_root_attributes": o.GetSetUserAttributes(),
 	}
 }
 
 func flattenConnectionOptionsAD(o *management.ConnectionOptionsAD) interface{} {
 	return map[string]interface{}{
-		"tenant_domain":          o.GetTenantDomain(),
-		"domain_aliases":         o.DomainAliases,
-		"icon_url":               o.GetLogoURL(),
-		"ips":                    o.IPs,
-		"use_cert_auth":          o.GetCertAuth(),
-		"use_kerberos":           o.GetKerberos(),
-		"disable_cache":          o.GetDisableCache(),
-		"brute_force_protection": o.GetBruteForceProtection(),
+		"tenant_domain":            o.GetTenantDomain(),
+		"domain_aliases":           o.DomainAliases,
+		"icon_url":                 o.GetLogoURL(),
+		"ips":                      o.IPs,
+		"use_cert_auth":            o.GetCertAuth(),
+		"use_kerberos":             o.GetKerberos(),
+		"disable_cache":            o.GetDisableCache(),
+		"brute_force_protection":   o.GetBruteForceProtection(),
+		"set_user_root_attributes": o.GetSetUserAttributes(),
 	}
 }
 
 func flattenConnectionOptionsAzureAD(o *management.ConnectionOptionsAzureAD) interface{} {
 	return map[string]interface{}{
-		"client_id":              o.GetClientID(),
-		"client_secret":          o.GetClientSecret(),
-		"app_id":                 o.GetAppID(),
-		"tenant_domain":          o.GetTenantDomain(),
-		"domain":                 o.GetDomain(),
-		"domain_aliases":         o.DomainAliases,
-		"icon_url":               o.GetLogoURL(),
-		"identity_api":           o.GetIdentityAPI(),
-		"waad_protocol":          o.GetWAADProtocol(),
-		"waad_common_endpoint":   o.GetUseCommonEndpoint(),
-		"use_wsfed":              o.GetUseWSFederation(),
-		"api_enable_users":       o.GetEnableUsersAPI(),
-		"max_groups_to_retrieve": o.GetMaxGroupsToRetrieve(),
-		"scopes":                 o.Scopes(),
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"app_id":                   o.GetAppID(),
+		"tenant_domain":            o.GetTenantDomain(),
+		"domain":                   o.GetDomain(),
+		"domain_aliases":           o.DomainAliases,
+		"icon_url":                 o.GetLogoURL(),
+		"identity_api":             o.GetIdentityAPI(),
+		"waad_protocol":            o.GetWAADProtocol(),
+		"waad_common_endpoint":     o.GetUseCommonEndpoint(),
+		"use_wsfed":                o.GetUseWSFederation(),
+		"api_enable_users":         o.GetEnableUsersAPI(),
+		"max_groups_to_retrieve":   o.GetMaxGroupsToRetrieve(),
+		"scopes":                   o.Scopes(),
+		"set_user_root_attributes": o.GetSetUserAttributes(),
 	}
 }
 
@@ -311,7 +321,8 @@ func expandConnectionOptionsGitHub(d ResourceData) *management.ConnectionOptions
 func expandConnectionOptionsAuth0(d ResourceData) *management.ConnectionOptions {
 
 	o := &management.ConnectionOptions{
-		PasswordPolicy: String(d, "password_policy"),
+		PasswordPolicy:    String(d, "password_policy"),
+		SetUserAttributes: String(d, "set_user_root_attributes"),
 	}
 
 	List(d, "validation").Elem(func(d ResourceData) {
@@ -366,9 +377,10 @@ func expandConnectionOptionsAuth0(d ResourceData) *management.ConnectionOptions 
 func expandConnectionOptionsGoogleOAuth2(d ResourceData) *management.ConnectionOptionsGoogleOAuth2 {
 
 	o := &management.ConnectionOptionsGoogleOAuth2{
-		ClientID:         String(d, "client_id"),
-		ClientSecret:     String(d, "client_secret"),
-		AllowedAudiences: Set(d, "allowed_audiences").List(),
+		ClientID:          String(d, "client_id"),
+		ClientSecret:      String(d, "client_secret"),
+		AllowedAudiences:  Set(d, "allowed_audiences").List(),
+		SetUserAttributes: String(d, "set_user_root_attributes"),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -378,10 +390,11 @@ func expandConnectionOptionsGoogleOAuth2(d ResourceData) *management.ConnectionO
 func expandConnectionOptionsOAuth2(d ResourceData) *management.ConnectionOptionsOAuth2 {
 
 	o := &management.ConnectionOptionsOAuth2{
-		ClientID:         String(d, "client_id"),
-		ClientSecret:     String(d, "client_secret"),
-		AuthorizationURL: String(d, "authorization_endpoint"),
-		TokenURL:         String(d, "token_endpoint"),
+		ClientID:          String(d, "client_id"),
+		ClientSecret:      String(d, "client_secret"),
+		AuthorizationURL:  String(d, "authorization_endpoint"),
+		TokenURL:          String(d, "token_endpoint"),
+		SetUserAttributes: String(d, "set_user_root_attributes"),
 	}
 	o.Scripts = Map(d, "scripts")
 
@@ -393,8 +406,9 @@ func expandConnectionOptionsOAuth2(d ResourceData) *management.ConnectionOptions
 func expandConnectionOptionsFacebook(d ResourceData) *management.ConnectionOptionsFacebook {
 
 	o := &management.ConnectionOptionsFacebook{
-		ClientID:     String(d, "client_id"),
-		ClientSecret: String(d, "client_secret"),
+		ClientID:          String(d, "client_id"),
+		ClientSecret:      String(d, "client_secret"),
+		SetUserAttributes: String(d, "set_user_root_attributes"),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -405,10 +419,11 @@ func expandConnectionOptionsFacebook(d ResourceData) *management.ConnectionOptio
 func expandConnectionOptionsApple(d ResourceData) *management.ConnectionOptionsApple {
 
 	o := &management.ConnectionOptionsApple{
-		ClientID:     String(d, "client_id"),
-		ClientSecret: String(d, "client_secret"),
-		TeamID:       String(d, "team_id"),
-		KeyID:        String(d, "key_id"),
+		ClientID:          String(d, "client_id"),
+		ClientSecret:      String(d, "client_secret"),
+		TeamID:            String(d, "team_id"),
+		KeyID:             String(d, "key_id"),
+		SetUserAttributes: String(d, "set_user_root_attributes"),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -419,9 +434,10 @@ func expandConnectionOptionsApple(d ResourceData) *management.ConnectionOptionsA
 func expandConnectionOptionsLinkedin(d ResourceData) *management.ConnectionOptionsLinkedin {
 
 	o := &management.ConnectionOptionsLinkedin{
-		ClientID:        String(d, "client_id"),
-		ClientSecret:    String(d, "client_secret"),
-		StrategyVersion: Int(d, "strategy_version"),
+		ClientID:          String(d, "client_id"),
+		ClientSecret:      String(d, "client_secret"),
+		StrategyVersion:   Int(d, "strategy_version"),
+		SetUserAttributes: String(d, "set_user_root_attributes"),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -432,9 +448,10 @@ func expandConnectionOptionsLinkedin(d ResourceData) *management.ConnectionOptio
 func expandConnectionOptionsSalesforce(d ResourceData) *management.ConnectionOptionsSalesforce {
 
 	o := &management.ConnectionOptionsSalesforce{
-		ClientID:         String(d, "client_id"),
-		ClientSecret:     String(d, "client_secret"),
-		CommunityBaseURL: String(d, "community_base_url"),
+		ClientID:          String(d, "client_id"),
+		ClientSecret:      String(d, "client_secret"),
+		CommunityBaseURL:  String(d, "community_base_url"),
+		SetUserAttributes: String(d, "set_user_root_attributes"),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -478,6 +495,7 @@ func expandConnectionOptionsEmail(d ResourceData) *management.ConnectionOptionsE
 			Body:    String(d, "template"),
 		},
 		BruteForceProtection: Bool(d, "brute_force_protection"),
+		SetUserAttributes:    String(d, "set_user_root_attributes"),
 	}
 
 	List(d, "totp").Elem(func(d ResourceData) {
@@ -493,13 +511,14 @@ func expandConnectionOptionsEmail(d ResourceData) *management.ConnectionOptionsE
 func expandConnectionOptionsAD(d ResourceData) *management.ConnectionOptionsAD {
 
 	o := &management.ConnectionOptionsAD{
-		DomainAliases: Set(d, "domain_aliases").List(),
-		TenantDomain:  String(d, "tenant_domain"),
-		LogoURL:       String(d, "icon_url"),
-		IPs:           Set(d, "ips").List(),
-		CertAuth:      Bool(d, "use_cert_auth"),
-		Kerberos:      Bool(d, "use_kerberos"),
-		DisableCache:  Bool(d, "disable_cache"),
+		DomainAliases:     Set(d, "domain_aliases").List(),
+		TenantDomain:      String(d, "tenant_domain"),
+		LogoURL:           String(d, "icon_url"),
+		IPs:               Set(d, "ips").List(),
+		CertAuth:          Bool(d, "use_cert_auth"),
+		Kerberos:          Bool(d, "use_kerberos"),
+		DisableCache:      Bool(d, "disable_cache"),
+		SetUserAttributes: String(d, "set_user_root_attributes"),
 	}
 
 	// `brute_force_protection` will default to true by the API if we don't
@@ -530,6 +549,7 @@ func expandConnectionOptionsAzureAD(d ResourceData) *management.ConnectionOption
 		EnableUsersAPI:      Bool(d, "api_enable_users"),
 		LogoURL:             String(d, "icon_url"),
 		IdentityAPI:         String(d, "identity_api"),
+		SetUserAttributes:   String(d, "set_user_root_attributes"),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -575,6 +595,7 @@ func expandConnectionOptionsSAML(d ResourceData) *management.ConnectionOptionsSA
 		RequestTemplate:    String(d, "request_template"),
 		UserIDAttribute:    String(d, "user_id_attribute"),
 		LogoURL:            String(d, "icon_url"),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
 	}
 
 	List(d, "idp_initiated").Elem(func(d ResourceData) {

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -75,6 +75,7 @@ With the `auth0` connection strategy, `options` supports the following arguments
 * `custom_scripts` - (Optional) Custom database action scripts. For more information, read [Custom Database Action Script Templates](https://auth0.com/docs/connections/database/custom-db/templates).
 * `configuration` - (Optional) A case-sensitive map of key value pairs used as configuration variables for the `custom_script`.
 * `mfa` - (Optional) Configuration settings Options for multifactor authentication. For details, see [MFA Options](#mfa-options).
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 
 
 #### Validation
@@ -126,6 +127,7 @@ With the `google-oauth2` connection strategy, `options` supports the following a
 * `client_secret` - (Optional) Facebook client secret.
 * `allowed_audiences` - (Optional) List of allowed audiences.
 * `scopes` - (Optional) Scopes.
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 
 
 
@@ -140,6 +142,7 @@ resource "auth0_connection" "google_oauth2" {
     client_secret = "<client-secret>"
     allowed_audiences = [ "example.com", "api.example.com" ]
     scopes = [ "email", "profile", "gmail", "youtube" ]
+    set_user_root_attributes = "on_each_login"
   }
 }
 ```
@@ -151,6 +154,7 @@ With the `facebook` connection strategy, `options` supports the following argume
 * `client_id` - (Optional) Facebook client ID.
 * `client_secret` - (Optional) Facebook client secret.
 * `scopes` - (Optional) Scopes.
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 
 **Example**:
 
@@ -175,6 +179,7 @@ With the `apple` connection strategy, `options` supports the following arguments
 * `team_id` - (Optional) Team ID.
 * `key_id` - (Optional) Key ID.
 * `scopes` - (Optional) Scopes.
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 
 **Example**:
 
@@ -200,6 +205,7 @@ With the `linkedin` connection strategy, `options` supports the following argume
 * `client_secret` - (Optional) Linkedin secret key.
 * `strategy_version` - (Optional) Version 1 is deprecated, use version 2.
 * `scopes` - (Optional) Scopes.
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 
 **Example**:
 
@@ -222,7 +228,7 @@ With the `github` connection strategy, `options` supports the following argument
 
 * `client_id` - (Optional) GitHub client ID.
 * `client_secret` - (Optional) GitHub client secret.
-* `set_user_root_attributes` - (Optional)
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 
 **Example**:
 
@@ -246,6 +252,7 @@ With the `salesforce`, `salesforce-community` and `salesforce-sandbox` connectio
 * `client_secret` - (Optional) The Salesforce client secret.
 * `community_base_url` - (Optional) String.
 * `scopes` - (Optional) Scopes.
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 
 **Example**:
 
@@ -285,6 +292,7 @@ With the `oauth2` connection strategy, `options` supports the following argument
 * `scopes` - (Optional) Scopes required by the connection. The value must be a list, for example `["openid", "profile", "email"]`.
 * `token_endpoint` - (Optional)
 * `authorization_endpoint` - (Optional)
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
   
 **Example**:
 
@@ -322,6 +330,7 @@ With the `waad` connection strategy, `options` supports the following arguments:
 * `use_wsfed` - (Optional)
 * `waad_protocol` - (Optional)
 * `waad_common_endpoint` - (Optional) Indicates whether or not to use the common endpoint rather than the default endpoint. Typically enabled if you're using this for a multi-tenant application in Azure AD.
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 
 ### Twilio / SMS
 
@@ -391,6 +400,7 @@ With the `samlp` connection strategy, `options` supports the following arguments
 * `digest_algorithm` - (Optional) Sign Request Algorithm Digest
 * `request_template` - (Optional) Template that formats the SAML request
 * `user_id_attribute` - (Optional) Attribute in the SAML token that will be mapped to the user_id property in Auth0.
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 
 **Example**:
 ```hcl


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Adds set_user_root_attributes to more connections
* Depends on https://github.com/go-auth0/auth0/pull/192


#### Acceptance Test Output

```
$ make testacc TESTS=TestAccXXX

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->