### PR TITLE
[WIP] Add options for github

### DIFF
--- a/auth0/resource_auth0_custom_domain.go
+++ b/auth0/resource_auth0_custom_domain.go
@@ -45,7 +45,7 @@ func newCustomDomain() *schema.Resource {
 			},
 			"verification_method": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"txt"}, true),
 			},


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.]

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

Make `vertification_method` in `custom_domain` optional so it matches the [API doc](https://auth0.com/docs/api/management/v2/#!/Custom_Domains/post_custom_domains).


#### Acceptance Test Output

```
$ make testacc TESTS=TestAccXXX

...
```

NOTE: at the moment these acceptance tests seem to be broken in master:

```
$ git reset --hard upstream/master
HEAD is now at 78dc295 Merge branch 'master' of github.com:alexkappa/terraform-provider-auth0 into master

$ make testacc TESTS=TestAccClient                                                                                        
==> Checking that code complies with gofmt requirements...
?       github.com/alexkappa/terraform-provider-auth0   [no test files]
=== RUN   TestAccClient
    testing.go:705: Step 0 error: config is invalid: 3 problems:
        
        - Missing required argument: The argument "client_id" is required, but was not set.
        - Missing required argument: The argument "client_secret" is required, but was not set.
        - Missing required argument: The argument "domain" is required, but was not set.
--- FAIL: TestAccClient (0.01s)
FAIL
coverage: 3.1% of statements
FAIL    github.com/alexkappa/terraform-provider-auth0/auth0     0.020s
?       github.com/alexkappa/terraform-provider-auth0/auth0/internal/debug      [no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0/internal/random     0.009s  coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0/internal/validation 0.018s  coverage: 0.0% of statements [no tests to run]
?       github.com/alexkappa/terraform-provider-auth0/version   [no test files]
FAIL
make: *** [GNUmakefile:26: testacc] Error 1
zsh: exit 2     make testacc TESTS=TestAccClient
```

I get the exact same result with my changes.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->