### PR TITLE
Hook up 'windowslive' social connection type

### DIFF
--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -1010,6 +1010,74 @@ resource "auth0_connection" "github" {
 }
 `
 
+func TestAccConnectionWindowslive(t *testing.T) {
+
+	rand := random.String(6)
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: random.Template(testAccConnectionWindowsliveConfig, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_connection.windowslive", "name", "Acceptance-Test-Windowslive-{{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "strategy", "windowslive"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.client_id", "client_id"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.client_secret", "client_secret"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.strategy_version", "2"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.scopes.#", "2"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.scopes.2458861461", "signin"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.scopes.3904585843", "graph_user"),
+				),
+			},
+			{
+				Config: random.Template(testAccConnectionWindowsliveConfigUpdate, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_connection.windowslive", "name", "Acceptance-Test-Windowslive-{{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "strategy", "windowslive"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.client_id", "client_id_update"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.client_secret", "client_secret_update"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.strategy_version", "2"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.scopes.#", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.windowslive", "options.0.scopes.2458861461", "signin"),
+				),
+			},
+		},
+	})
+}
+
+const testAccConnectionWindowsliveConfig = `
+
+resource "auth0_connection" "windowslive" {
+	name = "Acceptance-Test-Windowslive-{{.random}}"
+	is_domain_connection = false
+	strategy = "windowslive"
+	options {
+		client_id = "client_id"
+		client_secret = "client_secret"
+		strategy_version = 2
+		scopes = ["signin", "graph_user"]
+	}
+}
+`
+
+const testAccConnectionWindowsliveConfigUpdate = `
+
+resource "auth0_connection" "windowslive" {
+	name = "Acceptance-Test-Windowslive-{{.random}}"
+	is_domain_connection = false
+	strategy = "windowslive"
+	options {
+		client_id = "client_id_update"
+		client_secret = "client_secret_update"
+		strategy_version = 2
+		scopes = ["signin"]
+	}
+}
+`
+
 func TestAccConnectionConfiguration(t *testing.T) {
 
 	rand := random.String(6)

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -26,8 +26,8 @@ func flattenConnectionOptions(d ResourceData, options interface{}) []interface{}
 		m = flattenConnectionOptionsLinkedin(o)
 	case *management.ConnectionOptionsGitHub:
 		m = flattenConnectionOptionsGitHub(o)
-	// case *management.ConnectionOptionsWindowsLive:
-	// 	m = flattenConnectionOptionsWindowsLive(o)
+	case *management.ConnectionOptionsWindowsLive:
+		m = flattenConnectionOptionsWindowsLive(o)
 	case *management.ConnectionOptionsSalesforce:
 		m = flattenConnectionOptionsSalesforce(o)
 	case *management.ConnectionOptionsEmail:
@@ -53,6 +53,16 @@ func flattenConnectionOptionsGitHub(o *management.ConnectionOptionsGitHub) inter
 		"client_secret":            o.GetClientSecret(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
 		"scopes":                   o.Scopes(),
+	}
+}
+
+func flattenConnectionOptionsWindowsLive(o *management.ConnectionOptionsWindowsLive) interface{} {
+	return map[string]interface{}{
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"scopes":                   o.Scopes(),
+		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"strategy_version":         o.GetStrategyVersion(),
 	}
 }
 
@@ -279,7 +289,8 @@ func expandConnection(d ResourceData) *management.Connection {
 			c.Options = expandConnectionOptionsLinkedin(d)
 		case management.ConnectionStrategyGitHub:
 			c.Options = expandConnectionOptionsGitHub(d)
-		// 	management.ConnectionStrategyWindowsLive:
+		case management.ConnectionStrategyWindowsLive:
+			c.Options = expandConnectionOptionsWindowsLive(d)
 		case management.ConnectionStrategySalesforce,
 			management.ConnectionStrategySalesforceCommunity,
 			management.ConnectionStrategySalesforceSandbox:
@@ -450,6 +461,20 @@ func expandConnectionOptionsSalesforce(d ResourceData) *management.ConnectionOpt
 		ClientID:          String(d, "client_id"),
 		ClientSecret:      String(d, "client_secret"),
 		CommunityBaseURL:  String(d, "community_base_url"),
+		SetUserAttributes: String(d, "set_user_root_attributes"),
+	}
+
+	expandConnectionOptionsScopes(d, o)
+
+	return o
+}
+
+func expandConnectionOptionsWindowsLive(d ResourceData) *management.ConnectionOptionsWindowsLive {
+
+	o := &management.ConnectionOptionsWindowsLive{
+		ClientID:          String(d, "client_id"),
+		ClientSecret:      String(d, "client_secret"),
+		StrategyVersion:   Int(d, "strategy_version"),
 		SetUserAttributes: String(d, "set_user_root_attributes"),
 	}
 

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -426,6 +426,31 @@ resource "auth0_connection" "samlp" {
 }
 ```
 
+### Windowslive
+
+With the `windowslive` connection strategy, `options` supports the following arguments:
+
+* `client_id` - (Optional) API key.
+* `client_secret` - (Optional) secret key.
+* `strategy_version` - (Optional) Version 1 is deprecated, use version 2.
+* `scopes` - (Optional) Scopes.
+* `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
+
+**Example**:
+
+```hcl
+resource "auth0_connection" "windowslive" {
+  name = "Windowslive-Connection"
+  strategy = "windowslive"
+  options {
+    client_id = "<client-id>"
+    client_secret = "<client-secret>"
+    strategy_version = 2
+    scopes = [ "signin", "graph_user" ]
+  }
+}
+```
+
 ## Attribute Reference
 
 Attributes exported by this resource include:


### PR DESCRIPTION
<!--- 
**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 
--->
Fixes #320

### Proposed Changes
This hooks up the `windowslive` social connection that was commented out. 

I've tested it against my Auth0 tenant, and it seems to correctly provision and configure a Windows Live connection – i.e. "Try Connection" works after applying the plan shown below. However, I was kind of guessing my way through this, so any feedback would be welcome.

#### Example`terraform plan` output
```
# module.auth0_deployment.module.identity_providers_social.auth0_connection.windowslive will be created
+ resource "auth0_connection" "windowslive" {
    + enabled_clients      = [
        + "……",
        + "……",
      ]
    + id                   = (known after apply)
    + is_domain_connection = (known after apply)
    + name                 = "windowslive"
    + realms               = (known after apply)
    + strategy             = "windowslive"
    + strategy_version     = (known after apply)
    + options {
        + client_id                = "73831016-83b9-4215-a7a5-5be48677e743"
        + client_secret            = (sensitive value)
        + password_policy          = (known after apply)
        + scopes                   = [
            + "graph_user",
            + "signin",
          ]
        + set_user_root_attributes = (known after apply)
        + strategy_version         = 2
        + password_history {
            + enable = (known after apply)
            + size   = (known after apply)
          }
      }
  }
```

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccConnectionWindowslive
==> Checking that code complies with gofmt requirements...
?   	github.com/alexkappa/terraform-provider-auth0	[no test files]
=== RUN   TestAccConnectionWindowslive
--- PASS: TestAccConnectionWindowslive (2.57s)
PASS
coverage: 11.5% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0	3.144s	coverage: 11.5% of statements
?   	github.com/alexkappa/terraform-provider-auth0/auth0/internal/debug	[no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/random	0.385s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/validation	0.949s	coverage: 0.0% of statements [no tests to run]
?   	github.com/alexkappa/terraform-provider-auth0/version	[no test files]
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->