### PR TITLE
Revert Type schema change

### DIFF
--- a/auth0/resource_auth0_tenant.go
+++ b/auth0/resource_auth0_tenant.go
@@ -136,7 +136,7 @@ func newTenant() *schema.Resource {
 				ValidateFunc: validation.FloatAtLeast(0.01),
 			},
 			"enabled_locales": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 				Computed: true,


### PR DESCRIPTION
My test harness didn't capture the Type change. 

While #345 is right in that it is technically setup in Auth0, it only matters to the first object in the list. 

Reverting change. 