### PR TITLE
Fix Connection & Prompt tests 

### DIFF
--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -346,6 +346,7 @@ const testAccConnectionOIDCConfig = `
 
 resource "auth0_connection" "oidc" {
 	name     = "Acceptance-Test-OIDC-{{.random}}"
+	display_name     = "Acceptance-Test-OIDC-{{.random}}"
 	strategy = "oidc"
 	options {
 		client_id     = "123456"
@@ -371,6 +372,7 @@ const testAccConnectionOIDCConfigUpdate = `
 
 resource "auth0_connection" "oidc" {
 	name     = "Acceptance-Test-OIDC-{{.random}}"
+	display_name     = "Acceptance-Test-OIDC-{{.random}}"
 	strategy = "oidc"
 	options {
 		client_id     = "1234567"

--- a/auth0/resource_auth0_prompt_test.go
+++ b/auth0/resource_auth0_prompt_test.go
@@ -36,6 +36,7 @@ const testAccPromptCreate = `
 
 resource "auth0_prompt" "prompt" {
   universal_login_experience = "classic"
+  identifier_first = false
 }
 `
 


### PR DESCRIPTION
### Proposed Changes

* Fix `auth0/resource_auth0_connection_test.go` to also set a `display_name` for OIDC (fixes change made by #304) 
* Fix `auth0/resource_auth0_prompt_test.go` to send a `identifier_first` upon initial prompt changes. Upstream made a change where setting `universal_login_experience` to `classic` would set `identifier_first` to false. This was an assumption in the test and the test now sends `identifier_first` along side `universal_login_experience`. 

#### Acceptance Test Output

```
make testacc                                                              
==> Checking that code complies with gofmt requirements...
?   	github.com/alexkappa/terraform-provider-auth0	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_debugDefaults
--- PASS: TestProvider_debugDefaults (0.00s)
=== RUN   TestAccClientGrant
--- PASS: TestAccClientGrant (24.29s)
=== RUN   TestAccClient
--- PASS: TestAccClient (1.18s)
=== RUN   TestAccClientZeroValueCheck
--- PASS: TestAccClientZeroValueCheck (9.06s)
=== RUN   TestAccClientRotateSecret
--- PASS: TestAccClientRotateSecret (8.58s)
=== RUN   TestAccClientInitiateLoginUri
--- PASS: TestAccClientInitiateLoginUri (0.03s)
=== RUN   TestAccClientJwtScopes
--- PASS: TestAccClientJwtScopes (2.41s)
=== RUN   TestAccClientMobile
--- PASS: TestAccClientMobile (8.65s)
=== RUN   TestAccClientMobileValidationError
--- PASS: TestAccClientMobileValidationError (0.01s)
=== RUN   TestAccConnection
--- PASS: TestAccConnection (2.22s)
=== RUN   TestAccConnectionAD
--- PASS: TestAccConnectionAD (1.22s)
=== RUN   TestAccConnectionAzureAD
--- PASS: TestAccConnectionAzureAD (7.49s)
=== RUN   TestAccConnectionOIDC
--- PASS: TestAccConnectionOIDC (2.12s)
=== RUN   TestAccConnectionOAuth2
--- PASS: TestAccConnectionOAuth2 (8.22s)
=== RUN   TestAccConnectionWithEnbledClients
--- PASS: TestAccConnectionWithEnbledClients (14.53s)
=== RUN   TestAccConnectionSMS
--- PASS: TestAccConnectionSMS (1.42s)
=== RUN   TestAccConnectionEmail
--- PASS: TestAccConnectionEmail (2.09s)
=== RUN   TestAccConnectionSalesforce
--- PASS: TestAccConnectionSalesforce (7.28s)
=== RUN   TestAccConnectionGoogleOAuth2
--- PASS: TestAccConnectionGoogleOAuth2 (1.30s)
=== RUN   TestAccConnectionFacebook
--- PASS: TestAccConnectionFacebook (2.44s)
=== RUN   TestAccConnectionApple
--- PASS: TestAccConnectionApple (8.05s)
=== RUN   TestAccConnectionLinkedin
--- PASS: TestAccConnectionLinkedin (2.08s)
=== RUN   TestAccConnectionGitHub
--- PASS: TestAccConnectionGitHub (7.23s)
=== RUN   TestAccConnectionWindowslive
--- PASS: TestAccConnectionWindowslive (1.89s)
=== RUN   TestAccConnectionConfiguration
--- PASS: TestAccConnectionConfiguration (8.58s)
=== RUN   TestConnectionInstanceStateUpgradeV0
=== RUN   TestConnectionInstanceStateUpgradeV0/Empty
=== RUN   TestConnectionInstanceStateUpgradeV0/Zero
=== RUN   TestConnectionInstanceStateUpgradeV0/NonZero
=== RUN   TestConnectionInstanceStateUpgradeV0/Invalid
--- PASS: TestConnectionInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV0/Empty (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV0/Zero (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV0/NonZero (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV0/Invalid (0.00s)
=== RUN   TestConnectionInstanceStateUpgradeV1
=== RUN   TestConnectionInstanceStateUpgradeV1/Only_Min
=== RUN   TestConnectionInstanceStateUpgradeV1/Min_and_Max
--- PASS: TestConnectionInstanceStateUpgradeV1 (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV1/Only_Min (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV1/Min_and_Max (0.00s)
=== RUN   TestAccConnectionSAML
--- PASS: TestAccConnectionSAML (2.56s)
=== RUN   TestAccCustomDomain
--- PASS: TestAccCustomDomain (10.48s)
=== RUN   TestAccEmailTemplate
--- PASS: TestAccEmailTemplate (1.58s)
=== RUN   TestAccEmail
--- PASS: TestAccEmail (9.10s)
=== RUN   TestAccGlobalClient
--- PASS: TestAccGlobalClient (8.89s)
=== RUN   TestAccHook
--- PASS: TestAccHook (1.64s)
=== RUN   TestAccHookSecrets
--- PASS: TestAccHookSecrets (11.68s)
=== RUN   TestHookNameRegexp
--- PASS: TestHookNameRegexp (0.00s)
=== RUN   TestAccLogStreamHTTP
--- PASS: TestAccLogStreamHTTP (10.12s)
=== RUN   TestAccLogStreamEventBridge
--- PASS: TestAccLogStreamEventBridge (5.95s)
=== RUN   TestAccLogStreamEventGrid
    resource_auth0_log_stream_test.go:201: this test requires an active subscription
--- SKIP: TestAccLogStreamEventGrid (0.00s)
=== RUN   TestAccLogStreamDatadog
--- PASS: TestAccLogStreamDatadog (9.11s)
=== RUN   TestAccLogStreamSplunk
--- PASS: TestAccLogStreamSplunk (2.03s)
=== RUN   TestAccLogStreamSumo
--- PASS: TestAccLogStreamSumo (8.02s)
=== RUN   TestAccPrompt
--- PASS: TestAccPrompt (7.73s)
=== RUN   TestAccResourceServer
--- PASS: TestAccResourceServer (2.20s)
=== RUN   TestAccRole
--- PASS: TestAccRole (15.46s)
=== RUN   TestAccRolePermissions
--- PASS: TestAccRolePermissions (10.47s)
=== RUN   TestAccRuleConfig
--- PASS: TestAccRuleConfig (8.80s)
=== RUN   TestAccRule
--- PASS: TestAccRule (1.16s)
=== RUN   TestRuleNameRegexp
--- PASS: TestRuleNameRegexp (0.00s)
=== RUN   TestAccTenant
--- PASS: TestAccTenant (7.81s)
=== RUN   TestAccUserMissingRequiredParams
--- PASS: TestAccUserMissingRequiredParams (0.01s)
=== RUN   TestAccUser
--- PASS: TestAccUser (24.74s)
=== RUN   TestAccUserIssue218
--- PASS: TestAccUserIssue218 (8.19s)
=== RUN   TestAccUserChangeUsername
--- PASS: TestAccUserChangeUsername (9.18s)
=== RUN   TestMapData
=== RUN   TestMapData/GetOk
=== RUN   TestMapData/GetOkExists
--- PASS: TestMapData (0.00s)
    --- PASS: TestMapData/GetOk (0.00s)
    --- PASS: TestMapData/GetOkExists (0.00s)
=== RUN   TestJSON
--- PASS: TestJSON (0.00s)
=== RUN   TestIsNil
--- PASS: TestIsNil (0.00s)
PASS
coverage: 80.2% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0	309.279s	coverage: 80.2% of statements
?   	github.com/alexkappa/terraform-provider-auth0/auth0/internal/debug	[no test files]
=== RUN   TestString
--- PASS: TestString (0.00s)
=== RUN   TestTemplate
--- PASS: TestTemplate (0.00s)
PASS
coverage: 75.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/random	0.029s	coverage: 75.0% of statements
=== RUN   TestIsURLWithNoFragment
--- PASS: TestIsURLWithNoFragment (0.00s)
PASS
coverage: 52.9% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/validation	0.071s	coverage: 52.9% of statements
?   	github.com/alexkappa/terraform-provider-auth0/version	[no test files]
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->