### PR TITLE
Feature/updating locale support in tenant

### DIFF
--- a/auth0/resource_auth0_tenant.go
+++ b/auth0/resource_auth0_tenant.go
@@ -136,7 +136,7 @@ func newTenant() *schema.Resource {
 				ValidateFunc: validation.FloatAtLeast(0.01),
 			},
 			"enabled_locales": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 				Computed: true,
@@ -316,7 +316,7 @@ func buildTenant(d *schema.ResourceData) *management.Tenant {
 		SessionLifetime:     Float64(d, "session_lifetime"),
 		SandboxVersion:      String(d, "sandbox_version"),
 		IdleSessionLifetime: Float64(d, "idle_session_lifetime", IsNewResource(), HasChange()),
-		EnabledLocales:      Set(d, "enabled_locales").List(),
+		EnabledLocales:      List(d, "enabled_locales").List(),
 		ChangePassword:      expandTenantChangePassword(d),
 		GuardianMFAPage:     expandTenantGuardianMFAPage(d),
 		ErrorPage:           expandTenantErrorPage(d),

--- a/auth0/resource_auth0_tenant_test.go
+++ b/auth0/resource_auth0_tenant_test.go
@@ -31,12 +31,12 @@ func TestAccTenant(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "support_email", "support@mycompany.org"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "support_url", "https://mycompany.org/support"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "allowed_logout_urls.0", "https://mycompany.org/logoutCallback"),
-					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "session_lifetime", "1080"),
-					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "sandbox_version", "8"),
-					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "idle_session_lifetime", "720"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.4213735380", "en"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.421448744", "de"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.521772240", "fr"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "session_lifetime", "720"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "sandbox_version", "12"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "idle_session_lifetime", "72"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.universal_login", "true"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.disable_clickjack_protection_headers", "true"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.enable_public_signup_user_exists_error", "true"),
@@ -84,9 +84,9 @@ resource "auth0_tenant" "my_tenant" {
 	allowed_logout_urls = [
 		"https://mycompany.org/logoutCallback"
 	]
-	session_lifetime = 1080
-	sandbox_version = "8"
-	idle_session_lifetime = 720
+	session_lifetime = 720
+	sandbox_version = "12"
+	idle_session_lifetime = 72
 	enabled_locales = ["en", "de", "fr"]
 	flags {
 		universal_login = true
@@ -129,10 +129,10 @@ resource "auth0_tenant" "my_tenant" {
 	allowed_logout_urls = [
 		"https://mycompany.org/logoutCallback"
 	]
-	session_lifetime = 1080
-	sandbox_version = "8"
-	idle_session_lifetime = 720
 	enabled_locales = ["en", "de"]
+	session_lifetime = 720
+	sandbox_version = "12"
+	idle_session_lifetime = 72
 	flags {
 		universal_login = true
 		enable_public_signup_user_exists_error = true

--- a/auth0/resource_auth0_tenant_test.go
+++ b/auth0/resource_auth0_tenant_test.go
@@ -31,12 +31,12 @@ func TestAccTenant(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "support_email", "support@mycompany.org"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "support_url", "https://mycompany.org/support"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "allowed_logout_urls.0", "https://mycompany.org/logoutCallback"),
-					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.4213735380", "en"),
-					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.421448744", "de"),
-					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.521772240", "fr"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "session_lifetime", "720"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "sandbox_version", "12"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "idle_session_lifetime", "72"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.0", "en"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.1", "de"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.2", "fr"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.universal_login", "true"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.disable_clickjack_protection_headers", "true"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.enable_public_signup_user_exists_error", "true"),
@@ -49,8 +49,8 @@ func TestAccTenant(t *testing.T) {
 			{
 				Config: testAccTenantConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.4213735380", "en"),
-					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.421448744", "de"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.0", "de"),
+					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "enabled_locales.1", "fr"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.disable_clickjack_protection_headers", "false"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.enable_public_signup_user_exists_error", "true"),
 					resource.TestCheckResourceAttr("auth0_tenant.my_tenant", "flags.0.use_scope_descriptions_for_consent", "false"),
@@ -129,10 +129,10 @@ resource "auth0_tenant" "my_tenant" {
 	allowed_logout_urls = [
 		"https://mycompany.org/logoutCallback"
 	]
-	enabled_locales = ["en", "de"]
 	session_lifetime = 720
 	sandbox_version = "12"
 	idle_session_lifetime = 72
+	enabled_locales = ["de", "fr"]
 	flags {
 		universal_login = true
 		enable_public_signup_user_exists_error = true


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Changed to `TypeList` from `TypeSet` in `resource_auth0_tenant.go` as the order of arguments matter. The first locale in the list will be set as the default one.

Related to #353 and #345 

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccTenant

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->