### PR TITLE
Feature/adding denylist to connection resource

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -417,6 +417,13 @@ var connectionSchema = map[string]*schema.Schema{
 					}, false),
 					Description: "Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using an external IdP. Possible values are 'on_each_login' (default value, it configures the connection to automatically update the root attributes from the external IdP with each user login. When this setting is used, root attributes cannot be independently updated), 'on_first_login' (configures the connection to only set the root attributes on first login, allowing them to be independently updated thereafter)",
 				},
+				"non_persistent_attrs": {
+					Type:        schema.TypeSet,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+					Optional:    true,
+					Computed:    true,
+					Description: "If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the DenyList here",
+				},
 
 				// apple options
 				"team_id": {

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -202,6 +202,8 @@ func TestAccConnectionAD(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.ad", "options.0.domain_aliases.3506632655", "example.com"),
 					resource.TestCheckResourceAttr("auth0_connection.ad", "options.0.domain_aliases.3154807651", "api.example.com"),
 					resource.TestCheckResourceAttr("auth0_connection.ad", "options.0.set_user_root_attributes", "on_each_login"),
+					resource.TestCheckResourceAttr("auth0_connection.ad", "options.0.non_persistent_attrs.180730300", "ethnicity"),
+					resource.TestCheckResourceAttr("auth0_connection.ad", "options.0.non_persistent_attrs.4212941087", "gender"),
 				),
 			},
 		},
@@ -221,6 +223,7 @@ resource "auth0_connection" "ad" {
 		]
 		ips = [ "192.168.1.1", "192.168.1.2" ]
 		set_user_root_attributes = "on_each_login"
+		non_persistent_attrs = ["ethnicity","gender"]
 	}
 }
 `
@@ -316,6 +319,8 @@ func TestAccConnectionOIDC(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.scopes.4080487570", "profile"),
 					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.scopes.881205744", "email"),
 					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.set_user_root_attributes", "on_each_login"),
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.non_persistent_attrs.4212941087", "gender"),
+					resource.TestCheckResourceAttr("auth0_connection.oidc", "options.0.non_persistent_attrs.2145794573", "hair_color"),
 				),
 			},
 			{
@@ -364,6 +369,7 @@ resource "auth0_connection" "oidc" {
 		authorization_endpoint = "https://api.login.yahoo.com/oauth2/request_auth"
 		scopes                 = [ "openid", "email", "profile" ]
 		set_user_root_attributes = "on_each_login"
+		non_persistent_attrs = ["gender","hair_color"]
 	}
 }
 `

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -52,6 +52,7 @@ func flattenConnectionOptionsGitHub(o *management.ConnectionOptionsGitHub) inter
 		"client_id":                o.GetClientID(),
 		"client_secret":            o.GetClientSecret(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 		"scopes":                   o.Scopes(),
 	}
 }
@@ -62,6 +63,7 @@ func flattenConnectionOptionsWindowsLive(o *management.ConnectionOptionsWindowsL
 		"client_secret":            o.GetClientSecret(),
 		"scopes":                   o.Scopes(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 		"strategy_version":         o.GetStrategyVersion(),
 	}
 }
@@ -82,6 +84,7 @@ func flattenConnectionOptionsAuth0(d ResourceData, o *management.ConnectionOptio
 		"custom_scripts":                 o.CustomScripts,
 		"mfa":                            o.MFA,
 		"configuration":                  Map(d, "configuration"), // does not get read back
+		"non_persistent_attrs":           o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -92,6 +95,7 @@ func flattenConnectionOptionsGoogleOAuth2(o *management.ConnectionOptionsGoogleO
 		"allowed_audiences":        o.AllowedAudiences,
 		"scopes":                   o.Scopes(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -104,6 +108,7 @@ func flattenConnectionOptionsOAuth2(o *management.ConnectionOptionsOAuth2) inter
 		"authorization_endpoint":   o.GetAuthorizationURL(),
 		"scripts":                  o.Scripts,
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -113,6 +118,7 @@ func flattenConnectionOptionsFacebook(o *management.ConnectionOptionsFacebook) i
 		"client_secret":            o.GetClientSecret(),
 		"scopes":                   o.Scopes(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -124,6 +130,7 @@ func flattenConnectionOptionsApple(o *management.ConnectionOptionsApple) interfa
 		"key_id":                   o.GetKeyID(),
 		"scopes":                   o.Scopes(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -134,6 +141,7 @@ func flattenConnectionOptionsLinkedin(o *management.ConnectionOptionsLinkedin) i
 		"strategy_version":         o.GetStrategyVersion(),
 		"scopes":                   o.Scopes(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -144,6 +152,7 @@ func flattenConnectionOptionsSalesforce(o *management.ConnectionOptionsSalesforc
 		"community_base_url":       o.GetCommunityBaseURL(),
 		"scopes":                   o.Scopes(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -182,6 +191,7 @@ func flattenConnectionOptionsOIDC(o *management.ConnectionOptionsOIDC) interface
 		"userinfo_endpoint":        o.GetUserInfoEndpoint(),
 		"authorization_endpoint":   o.GetAuthorizationEndpoint(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -199,6 +209,7 @@ func flattenConnectionOptionsEmail(o *management.ConnectionOptionsEmail) interfa
 			"length":    o.OTP.GetLength(),
 		},
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -213,6 +224,7 @@ func flattenConnectionOptionsAD(o *management.ConnectionOptionsAD) interface{} {
 		"disable_cache":            o.GetDisableCache(),
 		"brute_force_protection":   o.GetBruteForceProtection(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -233,6 +245,7 @@ func flattenConnectionOptionsAzureAD(o *management.ConnectionOptionsAzureAD) int
 		"max_groups_to_retrieve":   o.GetMaxGroupsToRetrieve(),
 		"scopes":                   o.Scopes(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -258,6 +271,7 @@ func flattenConnectionOptionsSAML(o *management.ConnectionOptionsSAML) interface
 		"request_template":         o.GetRequestTemplate(),
 		"user_id_attribute":        o.GetUserIDAttribute(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
 }
 
@@ -319,10 +333,12 @@ func expandConnection(d ResourceData) *management.Connection {
 }
 
 func expandConnectionOptionsGitHub(d ResourceData) *management.ConnectionOptionsGitHub {
+
 	o := &management.ConnectionOptionsGitHub{
-		ClientID:          String(d, "client_id"),
-		ClientSecret:      String(d, "client_secret"),
-		SetUserAttributes: String(d, "set_user_root_attributes"),
+		ClientID:           String(d, "client_id"),
+		ClientSecret:       String(d, "client_secret"),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -333,7 +349,8 @@ func expandConnectionOptionsGitHub(d ResourceData) *management.ConnectionOptions
 func expandConnectionOptionsAuth0(d ResourceData) *management.ConnectionOptions {
 
 	o := &management.ConnectionOptions{
-		PasswordPolicy: String(d, "password_policy"),
+		PasswordPolicy:     String(d, "password_policy"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	List(d, "validation").Elem(func(d ResourceData) {
@@ -388,10 +405,11 @@ func expandConnectionOptionsAuth0(d ResourceData) *management.ConnectionOptions 
 func expandConnectionOptionsGoogleOAuth2(d ResourceData) *management.ConnectionOptionsGoogleOAuth2 {
 
 	o := &management.ConnectionOptionsGoogleOAuth2{
-		ClientID:          String(d, "client_id"),
-		ClientSecret:      String(d, "client_secret"),
-		AllowedAudiences:  Set(d, "allowed_audiences").List(),
-		SetUserAttributes: String(d, "set_user_root_attributes"),
+		ClientID:           String(d, "client_id"),
+		ClientSecret:       String(d, "client_secret"),
+		AllowedAudiences:   Set(d, "allowed_audiences").List(),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -401,11 +419,12 @@ func expandConnectionOptionsGoogleOAuth2(d ResourceData) *management.ConnectionO
 func expandConnectionOptionsOAuth2(d ResourceData) *management.ConnectionOptionsOAuth2 {
 
 	o := &management.ConnectionOptionsOAuth2{
-		ClientID:          String(d, "client_id"),
-		ClientSecret:      String(d, "client_secret"),
-		AuthorizationURL:  String(d, "authorization_endpoint"),
-		TokenURL:          String(d, "token_endpoint"),
-		SetUserAttributes: String(d, "set_user_root_attributes"),
+		ClientID:           String(d, "client_id"),
+		ClientSecret:       String(d, "client_secret"),
+		AuthorizationURL:   String(d, "authorization_endpoint"),
+		TokenURL:           String(d, "token_endpoint"),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 	o.Scripts = Map(d, "scripts")
 
@@ -417,9 +436,10 @@ func expandConnectionOptionsOAuth2(d ResourceData) *management.ConnectionOptions
 func expandConnectionOptionsFacebook(d ResourceData) *management.ConnectionOptionsFacebook {
 
 	o := &management.ConnectionOptionsFacebook{
-		ClientID:          String(d, "client_id"),
-		ClientSecret:      String(d, "client_secret"),
-		SetUserAttributes: String(d, "set_user_root_attributes"),
+		ClientID:           String(d, "client_id"),
+		ClientSecret:       String(d, "client_secret"),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -430,11 +450,12 @@ func expandConnectionOptionsFacebook(d ResourceData) *management.ConnectionOptio
 func expandConnectionOptionsApple(d ResourceData) *management.ConnectionOptionsApple {
 
 	o := &management.ConnectionOptionsApple{
-		ClientID:          String(d, "client_id"),
-		ClientSecret:      String(d, "client_secret"),
-		TeamID:            String(d, "team_id"),
-		KeyID:             String(d, "key_id"),
-		SetUserAttributes: String(d, "set_user_root_attributes"),
+		ClientID:           String(d, "client_id"),
+		ClientSecret:       String(d, "client_secret"),
+		TeamID:             String(d, "team_id"),
+		KeyID:              String(d, "key_id"),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -445,10 +466,11 @@ func expandConnectionOptionsApple(d ResourceData) *management.ConnectionOptionsA
 func expandConnectionOptionsLinkedin(d ResourceData) *management.ConnectionOptionsLinkedin {
 
 	o := &management.ConnectionOptionsLinkedin{
-		ClientID:          String(d, "client_id"),
-		ClientSecret:      String(d, "client_secret"),
-		StrategyVersion:   Int(d, "strategy_version"),
-		SetUserAttributes: String(d, "set_user_root_attributes"),
+		ClientID:           String(d, "client_id"),
+		ClientSecret:       String(d, "client_secret"),
+		StrategyVersion:    Int(d, "strategy_version"),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -459,10 +481,11 @@ func expandConnectionOptionsLinkedin(d ResourceData) *management.ConnectionOptio
 func expandConnectionOptionsSalesforce(d ResourceData) *management.ConnectionOptionsSalesforce {
 
 	o := &management.ConnectionOptionsSalesforce{
-		ClientID:          String(d, "client_id"),
-		ClientSecret:      String(d, "client_secret"),
-		CommunityBaseURL:  String(d, "community_base_url"),
-		SetUserAttributes: String(d, "set_user_root_attributes"),
+		ClientID:           String(d, "client_id"),
+		ClientSecret:       String(d, "client_secret"),
+		CommunityBaseURL:   String(d, "community_base_url"),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -473,10 +496,11 @@ func expandConnectionOptionsSalesforce(d ResourceData) *management.ConnectionOpt
 func expandConnectionOptionsWindowsLive(d ResourceData) *management.ConnectionOptionsWindowsLive {
 
 	o := &management.ConnectionOptionsWindowsLive{
-		ClientID:          String(d, "client_id"),
-		ClientSecret:      String(d, "client_secret"),
-		StrategyVersion:   Int(d, "strategy_version"),
-		SetUserAttributes: String(d, "set_user_root_attributes"),
+		ClientID:           String(d, "client_id"),
+		ClientSecret:       String(d, "client_secret"),
+		StrategyVersion:    Int(d, "strategy_version"),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -521,6 +545,7 @@ func expandConnectionOptionsEmail(d ResourceData) *management.ConnectionOptionsE
 		},
 		BruteForceProtection: Bool(d, "brute_force_protection"),
 		SetUserAttributes:    String(d, "set_user_root_attributes"),
+		NonPersistentAttrs:   castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	List(d, "totp").Elem(func(d ResourceData) {
@@ -536,14 +561,15 @@ func expandConnectionOptionsEmail(d ResourceData) *management.ConnectionOptionsE
 func expandConnectionOptionsAD(d ResourceData) *management.ConnectionOptionsAD {
 
 	o := &management.ConnectionOptionsAD{
-		DomainAliases:     Set(d, "domain_aliases").List(),
-		TenantDomain:      String(d, "tenant_domain"),
-		LogoURL:           String(d, "icon_url"),
-		IPs:               Set(d, "ips").List(),
-		CertAuth:          Bool(d, "use_cert_auth"),
-		Kerberos:          Bool(d, "use_kerberos"),
-		DisableCache:      Bool(d, "disable_cache"),
-		SetUserAttributes: String(d, "set_user_root_attributes"),
+		DomainAliases:      Set(d, "domain_aliases").List(),
+		TenantDomain:       String(d, "tenant_domain"),
+		LogoURL:            String(d, "icon_url"),
+		IPs:                Set(d, "ips").List(),
+		CertAuth:           Bool(d, "use_cert_auth"),
+		Kerberos:           Bool(d, "use_kerberos"),
+		DisableCache:       Bool(d, "disable_cache"),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	// `brute_force_protection` will default to true by the API if we don't
@@ -575,6 +601,7 @@ func expandConnectionOptionsAzureAD(d ResourceData) *management.ConnectionOption
 		LogoURL:             String(d, "icon_url"),
 		IdentityAPI:         String(d, "identity_api"),
 		SetUserAttributes:   String(d, "set_user_root_attributes"),
+		NonPersistentAttrs:  castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -598,6 +625,7 @@ func expandConnectionOptionsOIDC(d ResourceData) *management.ConnectionOptionsOI
 		UserInfoEndpoint:      String(d, "userinfo_endpoint"),
 		TokenEndpoint:         String(d, "token_endpoint"),
 		SetUserAttributes:     String(d, "set_user_root_attributes"),
+		NonPersistentAttrs:    castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	expandConnectionOptionsScopes(d, o)
@@ -622,6 +650,7 @@ func expandConnectionOptionsSAML(d ResourceData) *management.ConnectionOptionsSA
 		UserIDAttribute:    String(d, "user_id_attribute"),
 		LogoURL:            String(d, "icon_url"),
 		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
 	}
 
 	List(d, "idp_initiated").Elem(func(d ResourceData) {
@@ -649,4 +678,12 @@ func expandConnectionOptionsScopes(d ResourceData, s scoper) {
 	for _, scope := range rm {
 		s.SetScopes(false, scope.(string))
 	}
+}
+
+func castToListOfStrings(interfaces []interface{}) *[]string {
+	var strings []string
+	for _, v := range interfaces {
+		strings = append(strings, v.(string))
+	}
+	return &strings
 }

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -155,6 +155,7 @@ With the `facebook` connection strategy, `options` supports the following argume
 * `client_secret` - (Optional) Facebook client secret.
 * `scopes` - (Optional) Scopes.
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
+* `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
 
 **Example**:
 
@@ -180,6 +181,7 @@ With the `apple` connection strategy, `options` supports the following arguments
 * `key_id` - (Optional) Key ID.
 * `scopes` - (Optional) Scopes.
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
+* `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
 
 **Example**:
 
@@ -206,6 +208,7 @@ With the `linkedin` connection strategy, `options` supports the following argume
 * `strategy_version` - (Optional) Version 1 is deprecated, use version 2.
 * `scopes` - (Optional) Scopes.
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
+* `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
 
 **Example**:
 
@@ -229,6 +232,7 @@ With the `github` connection strategy, `options` supports the following argument
 * `client_id` - (Optional) GitHub client ID.
 * `client_secret` - (Optional) GitHub client secret.
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
+* `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
 
 **Example**:
 
@@ -253,6 +257,7 @@ With the `salesforce`, `salesforce-community` and `salesforce-sandbox` connectio
 * `community_base_url` - (Optional) String.
 * `scopes` - (Optional) Scopes.
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
+* `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
 
 **Example**:
 
@@ -282,6 +287,7 @@ With the `oidc` connection strategy, `options` supports the following arguments:
 * `token_endpoint` - (Optional)
 * `userinfo_endpoint` - (Optional)
 * `authorization_endpoint` - (Optional)
+* `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
 
 ### OAuth2
 
@@ -293,7 +299,8 @@ With the `oauth2` connection strategy, `options` supports the following argument
 * `token_endpoint` - (Optional)
 * `authorization_endpoint` - (Optional)
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
-  
+* `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
+
 **Example**:
 
 ```hcl
@@ -331,6 +338,7 @@ With the `waad` connection strategy, `options` supports the following arguments:
 * `waad_protocol` - (Optional)
 * `waad_common_endpoint` - (Optional) Indicates whether or not to use the common endpoint rather than the default endpoint. Typically enabled if you're using this for a multi-tenant application in Azure AD.
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
+* `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
 
 ### Twilio / SMS
 
@@ -401,6 +409,7 @@ With the `samlp` connection strategy, `options` supports the following arguments
 * `request_template` - (Optional) Template that formats the SAML request
 * `user_id_attribute` - (Optional) Attribute in the SAML token that will be mapped to the user_id property in Auth0.
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
+* `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
 
 **Example**:
 ```hcl
@@ -435,6 +444,7 @@ With the `windowslive` connection strategy, `options` supports the following arg
 * `strategy_version` - (Optional) Version 1 is deprecated, use version 2.
 * `scopes` - (Optional) Scopes.
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
+* `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
 
 **Example**:
 

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.15
 require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk v1.16.1
-	gopkg.in/auth0.v5 v5.13.0
+	gopkg.in/auth0.v5 v5.14.0
 )

--- a/go.sum
+++ b/go.sum
@@ -596,6 +596,8 @@ google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/auth0.v5 v5.13.0 h1:tTr6P0s0KhKYCr8Uci28uL+pSXjtRw68z8MblUg5lFA=
 gopkg.in/auth0.v5 v5.13.0/go.mod h1:jVm6ZyPgF3Y1XpY4SPMPQM9NtRl8o3o/e2OuezsX97E=
+gopkg.in/auth0.v5 v5.14.0 h1:xgyw6nW3AyXzOiF2tkp1DtLo26DwUK2tAcydfqYUbdY=
+gopkg.in/auth0.v5 v5.14.0/go.mod h1:WwEEBRaU1v8K4cpgbGOI7WogKhE7j/5dqfAtZvc79SI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -594,8 +594,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-gopkg.in/auth0.v5 v5.13.0 h1:tTr6P0s0KhKYCr8Uci28uL+pSXjtRw68z8MblUg5lFA=
-gopkg.in/auth0.v5 v5.13.0/go.mod h1:jVm6ZyPgF3Y1XpY4SPMPQM9NtRl8o3o/e2OuezsX97E=
 gopkg.in/auth0.v5 v5.14.0 h1:xgyw6nW3AyXzOiF2tkp1DtLo26DwUK2tAcydfqYUbdY=
 gopkg.in/auth0.v5 v5.14.0/go.mod h1:WwEEBRaU1v8K4cpgbGOI7WogKhE7j/5dqfAtZvc79SI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This PR introduces `non_persistent_attrs` which makes it possible to do what is described [here](https://auth0.com/docs/security/denylist-user-attributes)
through terraform. In short, fields put here will not be stored in the user data by Auth0 when they federate connections.
### Proposed Changes

* Adds `non_persistent_attrs` as a field for connection resources

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccConnection 

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->