### PR TITLE
Remove role_id from role documentation

### DIFF
--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -51,7 +51,6 @@ resource "auth0_role" "my_role" {
 
 Arguments accepted by this resource include:
 
-* `id` - (Optional) String. ID for this role.
 * `name` - (Required) String. Name for this role.
 * `description` - (Optional) String. Description of the role.
 * `user_ids` - (Optional) List(String). IDs of the users to which the role is assigned.


### PR DESCRIPTION
role_id looks to have been removed with this pull request https://github.com/alexkappa/terraform-provider-auth0/pull/202 but still appears in the documentation. This is misleading and can take trial and error, searching the code, or searching the github repo PRs/issues to determine that it is removed.

<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->