### PR TITLE
Add support for google-apps connection strategy options

### DIFF
--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -760,6 +760,55 @@ resource "auth0_connection" "google_oauth2" {
 }
 `
 
+func TestAccConnectionGoogleApps(t *testing.T) {
+
+	rand := random.String(6)
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: random.Template(testAccConnectionGoogleApps, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_connection.google_apps", "name", "Acceptance-Test-Google-Apps-{{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "strategy", "google-apps"),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.client_id", ""),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.client_secret", ""),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.domain", "example.com"),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.tenant_domain", "example.com"),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.domain_aliases.#", "2"),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.domain_aliases.3506632655", "example.com"),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.domain_aliases.3154807651", "api.example.com"),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.api_enable_users", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.scopes.#", "2"),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.scopes.1268340351", "ext_profile"),
+					resource.TestCheckResourceAttr("auth0_connection.google_apps", "options.0.scopes.541325467", "ext_groups"),
+				),
+			},
+		},
+	})
+}
+
+const testAccConnectionGoogleApps = `
+
+resource "auth0_connection" "google_apps" {
+	name = "Acceptance-Test-Google-Apps-{{.random}}"
+	is_domain_connection = false
+	strategy = "google-apps"
+	options {
+		client_id = ""
+		client_secret = ""
+		domain = "example.com"
+		tenant_domain = "example.com"
+		domain_aliases = [ "example.com", "api.example.com" ]
+		api_enable_users = true
+		scopes = [ "ext_profile", "ext_groups" ]
+	}
+}
+`
+
 func TestAccConnectionFacebook(t *testing.T) {
 
 	rand := random.String(6)

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -16,6 +16,8 @@ func flattenConnectionOptions(d ResourceData, options interface{}) []interface{}
 		m = flattenConnectionOptionsAuth0(d, o)
 	case *management.ConnectionOptionsGoogleOAuth2:
 		m = flattenConnectionOptionsGoogleOAuth2(o)
+	case *management.ConnectionOptionsGoogleApps:
+		m = flattenConnectionOptionsGoogleApps(o)
 	case *management.ConnectionOptionsOAuth2:
 		m = flattenConnectionOptionsOAuth2(o)
 	case *management.ConnectionOptionsFacebook:
@@ -96,6 +98,21 @@ func flattenConnectionOptionsGoogleOAuth2(o *management.ConnectionOptionsGoogleO
 		"scopes":                   o.Scopes(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
 		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+	}
+}
+
+func flattenConnectionOptionsGoogleApps(o *management.ConnectionOptionsGoogleApps) interface{} {
+	return map[string]interface{}{
+		"client_id":                o.GetClientID(),
+		"client_secret":            o.GetClientSecret(),
+		"domain":                   o.GetDomain(),
+		"tenant_domain":            o.GetTenantDomain(),
+		"api_enable_users":         o.GetEnableUsersAPI(),
+		"scopes":                   o.Scopes(),
+		"set_user_root_attributes": o.GetSetUserAttributes(),
+		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+		"domain_aliases":           o.DomainAliases,
+		"icon_url":                 o.GetLogoURL(),
 	}
 }
 
@@ -295,6 +312,8 @@ func expandConnection(d ResourceData) *management.Connection {
 			c.Options = expandConnectionOptionsAuth0(d)
 		case management.ConnectionStrategyGoogleOAuth2:
 			c.Options = expandConnectionOptionsGoogleOAuth2(d)
+		case management.ConnectionStrategyGoogleApps:
+			c.Options = expandConnectionOptionsGoogleApps(d)
 		case management.ConnectionStrategyOAuth2:
 			c.Options = expandConnectionOptionsOAuth2(d)
 		case management.ConnectionStrategyFacebook:
@@ -417,6 +436,26 @@ func expandConnectionOptionsGoogleOAuth2(d ResourceData) *management.ConnectionO
 
 	return o
 }
+
+func expandConnectionOptionsGoogleApps(d ResourceData) *management.ConnectionOptionsGoogleApps {
+
+	o := &management.ConnectionOptionsGoogleApps{
+		ClientID:           String(d, "client_id"),
+		ClientSecret:       String(d, "client_secret"),
+		Domain:             String(d, "domain"),
+		TenantDomain:       String(d, "tenant_domain"),
+		EnableUsersAPI:     Bool(d, "api_enable_users"),
+		SetUserAttributes:  String(d, "set_user_root_attributes"),
+		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
+		DomainAliases:      Set(d, "domain_aliases").List(),
+		LogoURL:            String(d, "icon_url"),
+	}
+
+	expandConnectionOptionsScopes(d, o)
+
+	return o
+}
+
 func expandConnectionOptionsOAuth2(d ResourceData) *management.ConnectionOptionsOAuth2 {
 
 	o := &management.ConnectionOptionsOAuth2{


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Add support for google-apps connection strategy options

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccConnectionGoogleApps
==> Checking that code complies with gofmt requirements...
?   	github.com/alexkappa/terraform-provider-auth0	[no test files]
=== RUN   TestAccConnectionGoogleApps
--- PASS: TestAccConnectionGoogleApps (2.15s)
PASS
coverage: 9.1% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0	2.394s	coverage: 9.1% of statements
?   	github.com/alexkappa/terraform-provider-auth0/auth0/internal/debug	[no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/random	0.171s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/validation	0.131s	coverage: 0.0% of statements [no tests to run]
?   	github.com/alexkappa/terraform-provider-auth0/version	[no test files]

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->