### PR TITLE
(docs): Fixed documentation of Optional argument.

### DIFF
--- a/docs/resources/email_template.md
+++ b/docs/resources/email_template.md
@@ -44,7 +44,7 @@ Arguments accepted by this resource include:
 * `template` - (Required) String. Template name. Options include `verify_email`, `verify_email_by_code`, `reset_email`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `change_password` (legacy), and `password_reset` (legacy).
 * `body` - (Required) String. Body of the email template. You can include [common variables](https://auth0.com/docs/email/templates#common-variables).
 * `from` - (Required) String. Email address to use as the sender. You can include [common variables](https://auth0.com/docs/email/templates#common-variables).
-* `result_url` - (Required) String. URL to redirect the user to after a successful action. [Learn more](https://auth0.com/docs/email/templates#configuring-the-redirect-to-url).
+* `result_url` - (Optional) String. URL to redirect the user to after a successful action. [Learn more](https://auth0.com/docs/email/templates#configuring-the-redirect-to-url).
 * `subject` - (Required) String. Subject line of the email. You can include [common variables](https://auth0.com/docs/email/templates#common-variables).
 * `syntax` - (Required) String. Syntax of the template body. You can use either text or HTML + Liquid syntax.
 * `url_lifetime_in_seconds` - (Optional) Integer. Number of seconds during which the link within the email will be valid.


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Updates docs to match the `auth0_email_template.result_url` schema which should be optional based on https://github.com/alexkappa/terraform-provider-auth0/blob/master/auth0/resource_auth0_email_template.go#L50.


#### Acceptance Test Output

```
$ make testacc TESTS=TestAccXXX

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->