### PR TITLE
Fix reading auth0_branding when enable_custom_domain_in_emails is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.26.1
+
+BUG FIXES:
+
+* resource/auth0_branding: Fix reading auth0_branding when enable_custom_domain_in_emails flag is true ([#438](https://github.com/alexkappa/terraform-provider-auth0/pull/438))
+
 ## 0.26.0
 
 ENHANCEMENTS:


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at :x

--->
### Proposed Changes

* Enables you to set auth0_branding when custom domain is enabled and universal_login is not set
	* By current provider behavior, when custom domain is enabled, custom universal login pages must be set. From [document](https://auth0.com/docs/brand-and-customize/universal-login-page-templates), when custom domain is enabled, it is true that universal login pages can be set, but you don't have to.

Fixes #380 

#### Acceptance Test Output

```bash
$ make testacc TESTS=TestAccBranding                                                         
==> Checking that code complies with gofmt requirements...
?       github.com/alexkappa/terraform-provider-auth0   [no test files]
=== RUN   TestAccBranding
--- PASS: TestAccBranding (8.76s)
PASS
coverage: 7.6% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0     9.120s  coverage: 7.6% of statements
?       github.com/alexkappa/terraform-provider-auth0/auth0/internal/debug      [no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0/internal/random     0.423s  coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0/internal/validation 0.478s  coverage: 0.0% of statements [no tests to run]
?       github.com/alexkappa/terraform-provider-auth0/version   [no test files]
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->