### PR TITLE
feat(log_stream): support JSONOBJECT format

### DIFF
--- a/auth0/resource_auth0_log_stream.go
+++ b/auth0/resource_auth0_log_stream.go
@@ -102,10 +102,11 @@ func newLogStream() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							RequiredWith: []string{"sink.0.http_endpoint", "sink.0.http_authorization", "sink.0.http_content_type"},
-							Description:  "HTTP Content Format can be JSONLINES or JSONARRAY",
+							Description:  "HTTP Content Format can be JSONLINES, JSONARRAY or JSONOBJECT",
 							ValidateFunc: validation.StringInSlice([]string{
 								"JSONLINES",
 								"JSONARRAY",
+								"JSONOBJECT",
 							}, false),
 						},
 						"http_content_type": {

--- a/auth0/resource_auth0_log_stream_test.go
+++ b/auth0/resource_auth0_log_stream_test.go
@@ -72,7 +72,7 @@ func TestAccLogStreamHTTP(t *testing.T) {
 				),
 			},
 			{
-				Config: random.Template(testAccLogStreamHTTPConfigUpdateFormat, rand),
+				Config: random.Template(testAccLogStreamHTTPConfigUpdateJsonObject, rand),
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-http-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "http"),

--- a/auth0/resource_auth0_log_stream_test.go
+++ b/auth0/resource_auth0_log_stream_test.go
@@ -72,6 +72,17 @@ func TestAccLogStreamHTTP(t *testing.T) {
 				),
 			},
 			{
+				Config: random.Template(testAccLogStreamHTTPConfigUpdateFormat, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-http-{{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "http"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_endpoint", "https://example.com/webhook/logs"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_content_type", "application/json; charset=utf-8"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_content_format", "JSONOBJECT"),
+					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "sink.0.http_authorization", "AKIAXXXXXXXXXXXXXXXX"),
+				),
+			},
+			{
 				Config: random.Template(testAccLogStreamHTTPConfigUpdate, rand),
 				Check: resource.ComposeTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-http-new-{{.random}}", rand),
@@ -107,6 +118,18 @@ resource "auth0_log_stream" "my_log_stream" {
 	  http_endpoint = "https://example.com/logs"
 	  http_content_type = "application/json"
 	  http_content_format = "JSONLINES"
+	  http_authorization = "AKIAXXXXXXXXXXXXXXXX"
+	}
+}
+`
+const testAccLogStreamHTTPConfigUpdateJsonObject = `
+resource "auth0_log_stream" "my_log_stream" {
+	name = "Acceptance-Test-LogStream-http-new-{{.random}}"
+	type = "http"
+	sink {
+	  http_endpoint = "https://example.com/logs"
+	  http_content_type = "application/json"
+	  http_content_format = "JSONOBJECT"
 	  http_authorization = "AKIAXXXXXXXXXXXXXXXX"
 	}
 }

--- a/docs/resources/log_stream.md
+++ b/docs/resources/log_stream.md
@@ -48,7 +48,7 @@ For "eventgrid" the following arguments are supported:
 - `azure_partner_topic` - (Optional, Computed) Name of the Partner Topic to be used with Azure.  Generally should not be specified.
 
 For "http" the following arguments are supported:
-- `http_content_format` - (Required) The format of data sent over HTTP. Options are "JSONLINES" or "JSONARRAY"
+- `http_content_format` - (Required) The format of data sent over HTTP. Options are "JSONLINES", "JSONARRAY" or "JSONOBJECT"
 - `http_content_type` - (Required) The ContentType header to send over HTTP.  Common value is "application/json"
 - `http_endpoint` - (Required) The HTTP endpoint to send streaming logs
 - `http_authorization` - (Required) Sent in the HTTP "Authorization" header with each request

--- a/example/log_stream/main.tf
+++ b/example/log_stream/main.tf
@@ -1,0 +1,22 @@
+provider "auth0" {}
+
+resource "auth0_log_stream" "example_http" {
+  name = "HTTP log stream"
+  type = "http"
+  sink {
+    http_endpoint       = "https://example.com/logs"
+    http_content_type   = "application/json"
+    http_content_format = "JSONOBJECT"
+    http_authorization  = "AKIAXXXXXXXXXXXXXXXX"
+  }
+}
+
+resource "auth0_log_stream" "example_aws" {
+  name   = "AWS Eventbridge"
+  type   = "eventbridge"
+  status = "active"
+  sink {
+    aws_account_id = "my_account_id"
+    aws_region     = "us-east-2"
+  }
+}


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Add support for JSONOBJECT form for http log stream. This feature is supported in the UI and should be in terraform provider.

![crop](https://user-images.githubusercontent.com/5888932/132899703-e911d14f-1e2f-49c6-9741-8a75297e88d9.png)

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->