### PR TITLE
chore: fix #385 connection import

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -124,6 +124,7 @@ var connectionSchema = map[string]*schema.Schema{
 				},
 				"password_history": {
 					Type:     schema.TypeList,
+					MaxItems: 1,
 					Optional: true,
 					Computed: true,
 					Elem: &schema.Resource{
@@ -726,7 +727,9 @@ func readConnection(d *schema.ResourceData, m interface{}) error {
 	d.Set("display_name", c.DisplayName)
 	d.Set("is_domain_connection", c.IsDomainConnection)
 	d.Set("strategy", c.Strategy)
-	d.Set("options", flattenConnectionOptions(d, c.Options))
+	if err := d.Set("options", flattenConnectionOptions(d, c.Options)); err != nil {
+		return err
+	}
 	d.Set("enabled_clients", c.EnabledClients)
 	d.Set("realms", c.Realms)
 	return nil

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -76,7 +76,6 @@ func TestAccConnection(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.import_mode", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.disable_signup", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.requires_username", "true"),
-					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.set_user_root_attributes", "on_each_login"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.0.username.0.min", "10"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.validation.0.username.0.max", "40"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.custom_scripts.get_user", "myFunction"),
@@ -90,7 +89,6 @@ func TestAccConnection(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.brute_force_protection", "false"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.mfa.0.return_enroll_settings", "false"),
-					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.set_user_root_attributes", "on_first_login"),
 				),
 			},
 		},
@@ -140,7 +138,6 @@ resource "auth0_connection" "my_connection" {
 			active                 = true
 			return_enroll_settings = true
 		}
-		set_user_root_attributes = "on_each_login"
 	}
 }
 `
@@ -175,7 +172,6 @@ resource "auth0_connection" "my_connection" {
 			active                 = true
 			return_enroll_settings = false
 		}
-		set_user_root_attributes = "on_first_login"
 	}
 }
 `

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -44,6 +44,9 @@ func flattenConnectionOptions(d ResourceData, options interface{}) []interface{}
 		m = flattenConnectionOptionsSAML(o)
 	}
 
+	if m == nil {
+		return nil
+	}
 	return []interface{}{m}
 }
 
@@ -109,7 +112,7 @@ func flattenConnectionOptionsGoogleOAuth2(o *management.ConnectionOptionsGoogleO
 	return map[string]interface{}{
 		"client_id":                o.GetClientID(),
 		"client_secret":            o.GetClientSecret(),
-		"allowed_audiences":        o.AllowedAudiences,
+		"allowed_audiences":        listOrNil(o.AllowedAudiences),
 		"scopes":                   o.Scopes(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
 		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
@@ -184,10 +187,10 @@ func flattenConnectionOptionsSMS(o *management.ConnectionOptionsSMS) interface{}
 		"messaging_service_sid":  o.GetMessagingServiceSID(),
 		"disable_signup":         o.GetDisableSignup(),
 		"brute_force_protection": o.GetBruteForceProtection(),
-		"totp": map[string]interface{}{
+		"totp": mapToList(map[string]interface{}{
 			"time_step": o.OTP.GetTimeStep(),
 			"length":    o.OTP.GetLength(),
-		},
+		}),
 	}
 }
 
@@ -197,7 +200,7 @@ func flattenConnectionOptionsOIDC(o *management.ConnectionOptionsOIDC) interface
 		"client_secret":  o.GetClientSecret(),
 		"icon_url":       o.GetLogoURL(),
 		"tenant_domain":  o.GetTenantDomain(),
-		"domain_aliases": o.DomainAliases,
+		"domain_aliases": listOrNil(o.DomainAliases),
 
 		"type":                     o.GetType(),
 		"scopes":                   o.Scopes(),
@@ -212,6 +215,13 @@ func flattenConnectionOptionsOIDC(o *management.ConnectionOptionsOIDC) interface
 	}
 }
 
+func listOrNil(l []interface{}) []interface{} {
+	if l == nil {
+		return []interface{}{}
+	}
+	return l
+}
+
 func flattenConnectionOptionsEmail(o *management.ConnectionOptionsEmail) interface{} {
 	return map[string]interface{}{
 		"name":                   o.GetName(),
@@ -221,10 +231,10 @@ func flattenConnectionOptionsEmail(o *management.ConnectionOptionsEmail) interfa
 		"template":               o.GetEmail().GetBody(),
 		"disable_signup":         o.GetDisableSignup(),
 		"brute_force_protection": o.GetBruteForceProtection(),
-		"totp": map[string]interface{}{
+		"totp": mapToList(map[string]interface{}{
 			"time_step": o.OTP.GetTimeStep(),
 			"length":    o.OTP.GetLength(),
-		},
+		}),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
 		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
 	}
@@ -233,9 +243,9 @@ func flattenConnectionOptionsEmail(o *management.ConnectionOptionsEmail) interfa
 func flattenConnectionOptionsAD(o *management.ConnectionOptionsAD) interface{} {
 	return map[string]interface{}{
 		"tenant_domain":            o.GetTenantDomain(),
-		"domain_aliases":           o.DomainAliases,
+		"domain_aliases":           listOrNil(o.DomainAliases),
 		"icon_url":                 o.GetLogoURL(),
-		"ips":                      o.IPs,
+		"ips":                      listOrNil(o.IPs),
 		"use_cert_auth":            o.GetCertAuth(),
 		"use_kerberos":             o.GetKerberos(),
 		"disable_cache":            o.GetDisableCache(),
@@ -252,7 +262,7 @@ func flattenConnectionOptionsAzureAD(o *management.ConnectionOptionsAzureAD) int
 		"app_id":                                 o.GetAppID(),
 		"tenant_domain":                          o.GetTenantDomain(),
 		"domain":                                 o.GetDomain(),
-		"domain_aliases":                         o.DomainAliases,
+		"domain_aliases":                         listOrNil(o.DomainAliases),
 		"icon_url":                               o.GetLogoURL(),
 		"identity_api":                           o.GetIdentityAPI(),
 		"waad_protocol":                          o.GetWAADProtocol(),
@@ -272,13 +282,13 @@ func flattenConnectionOptionsSAML(o *management.ConnectionOptionsSAML) interface
 		"signing_cert":     o.GetSigningCert(),
 		"protocol_binding": o.GetProtocolBinding(),
 		"debug":            o.GetDebug(),
-		"idp_initiated": map[string]interface{}{
+		"idp_initiated": mapToList(map[string]interface{}{
 			"client_id":              o.IdpInitiated.GetClientID(),
 			"client_protocol":        o.IdpInitiated.GetClientProtocol(),
 			"client_authorize_query": o.IdpInitiated.GetClientAuthorizeQuery(),
-		},
+		}),
 		"tenant_domain":            o.GetTenantDomain(),
-		"domain_aliases":           o.DomainAliases,
+		"domain_aliases":           listOrNil(o.DomainAliases),
 		"sign_in_endpoint":         o.GetSignInEndpoint(),
 		"sign_out_endpoint":        o.GetSignOutEndpoint(),
 		"signature_algorithm":      o.GetSignatureAlgorithm(),

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -70,19 +70,19 @@ func flattenConnectionOptionsWindowsLive(o *management.ConnectionOptionsWindowsL
 
 func flattenConnectionOptionsAuth0(d ResourceData, o *management.ConnectionOptions) interface{} {
 	return map[string]interface{}{
-		"validation":                     o.Validation,
+		"validation":                     []interface{}{o.Validation},
 		"password_policy":                o.GetPasswordPolicy(),
-		"password_history":               o.PasswordHistory,
-		"password_no_personal_info":      o.PasswordNoPersonalInfo,
-		"password_dictionary":            o.PasswordDictionary,
-		"password_complexity_options":    o.PasswordComplexityOptions,
+		"password_history":               []interface{}{o.PasswordHistory},
+		"password_no_personal_info":      []interface{}{o.PasswordNoPersonalInfo},
+		"password_dictionary":            []interface{}{o.PasswordDictionary},
+		"password_complexity_options":    []interface{}{o.PasswordComplexityOptions},
 		"enabled_database_customization": o.GetEnabledDatabaseCustomization(),
 		"brute_force_protection":         o.GetBruteForceProtection(),
 		"import_mode":                    o.GetImportMode(),
 		"disable_signup":                 o.GetDisableSignup(),
 		"requires_username":              o.GetRequiresUsername(),
 		"custom_scripts":                 o.CustomScripts,
-		"mfa":                            o.MFA,
+		"mfa":                            []interface{}{o.MFA},
 		"configuration":                  Map(d, "configuration"), // does not get read back
 		"non_persistent_attrs":           o.GetNonPersistentAttrs(),
 	}


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Updates the flattenConnectionOptions chain to correctly return lists where applicable
* Ensures that errors are handled when importing other connection options

Fixes #385 

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccConnection
==> Checking that code complies with gofmt requirements...
?   	github.com/alexkappa/terraform-provider-auth0	[no test files]
=== RUN   TestAccConnection
--- PASS: TestAccConnection (2.09s)
PASS
coverage: 12.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0	2.110s	coverage: 12.0% of statements
?   	github.com/alexkappa/terraform-provider-auth0/auth0/internal/debug	[no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/random	0.014s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/validation	0.002s	coverage: 0.0% of statements [no tests to run]
?   	github.com/alexkappa/terraform-provider-auth0/version	[no test files]
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->