### PR TITLE
Support entity_id in samlp connection

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -588,6 +588,11 @@ var connectionSchema = map[string]*schema.Schema{
 					Optional:    true,
 					Description: "Sign Request Algorithm Digest",
 				},
+				"entity_id": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Custom Entity ID for the connection",
+				},
 			},
 		},
 		Description: "Configuration settings for connection options",

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -1290,6 +1290,7 @@ func TestAccConnectionSAML(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.idp_initiated.0.client_authorize_query", "type=code&timeout=60"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.sign_out_endpoint", ""),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.entity_id", "example"),
 				),
 			},
 		},
@@ -1388,6 +1389,7 @@ EOF
 		protocol_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post"
 		signature_algorithm = "rsa-sha256"
 		digest_algorithm = "sha256"
+		entity_id = "example"
 		fields_map = {
 			foo = "bar"
 			baz = "baa"

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -273,6 +273,7 @@ func flattenConnectionOptionsSAML(o *management.ConnectionOptionsSAML) interface
 		"user_id_attribute":        o.GetUserIDAttribute(),
 		"set_user_root_attributes": o.GetSetUserAttributes(),
 		"non_persistent_attrs":     o.GetNonPersistentAttrs(),
+		"entity_id":                o.GetEntityID(),
 	}
 }
 
@@ -653,6 +654,7 @@ func expandConnectionOptionsSAML(d ResourceData) *management.ConnectionOptionsSA
 		LogoURL:            String(d, "icon_url"),
 		SetUserAttributes:  String(d, "set_user_root_attributes"),
 		NonPersistentAttrs: castToListOfStrings(Set(d, "non_persistent_attrs").List()),
+		EntityID:           String(d, "entity_id"),
 	}
 
 	List(d, "idp_initiated").Elem(func(d ResourceData) {

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -411,6 +411,7 @@ With the `samlp` connection strategy, `options` supports the following arguments
 * `user_id_attribute` - (Optional) Attribute in the SAML token that will be mapped to the user_id property in Auth0.
 * `set_user_root_attributes` - (Optional) Determines whether the 'name', 'given_name', 'family_name', 'nickname', and 'picture' attributes can be independently updated when using the external IdP. Default is `on_each_login` and can be set to `on_first_login`.
 * `non_persistent_attrs` - (Optional) If there are user fields that should not be stored in Auth0 databases due to privacy reasons, you can add them to the denylist. See [here](https://auth0.com/docs/security/denylist-user-attributes) for more info.
+* `entity_id` - (Optional) Custom Entity ID for the connection.
 
 **Example**:
 ```hcl


### PR DESCRIPTION
### Proposed Changes

* Extend existing auth0_connection resource to support custom Entity ID in samlp connection options

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccXXX
==> Checking that code complies with gofmt requirements...
?       github.com/alexkappa/terraform-provider-auth0   [no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_debugDefaults
--- PASS: TestProvider_debugDefaults (0.00s)
=== RUN   TestAccBranding
--- PASS: TestAccBranding (5.07s)
=== RUN   TestAccClientGrant
--- PASS: TestAccClientGrant (26.83s)
=== RUN   TestAccClient
--- PASS: TestAccClient (2.73s)
=== RUN   TestAccClientZeroValueCheck
--- PASS: TestAccClientZeroValueCheck (5.70s)
=== RUN   TestAccClientRotateSecret
--- PASS: TestAccClientRotateSecret (3.92s)
=== RUN   TestAccClientInitiateLoginUri
--- PASS: TestAccClientInitiateLoginUri (0.03s)
=== RUN   TestAccClientJwtScopes
--- PASS: TestAccClientJwtScopes (3.42s)
=== RUN   TestAccClientMobile
--- PASS: TestAccClientMobile (3.67s)
=== RUN   TestAccClientMobileValidationError
--- PASS: TestAccClientMobileValidationError (0.01s)
=== RUN   TestAccConnection
--- PASS: TestAccConnection (9.20s)
=== RUN   TestAccConnectionAD
--- PASS: TestAccConnectionAD (2.11s)
=== RUN   TestAccConnectionAzureAD
--- PASS: TestAccConnectionAzureAD (3.50s)
=== RUN   TestAccConnectionOIDC
--- PASS: TestAccConnectionOIDC (4.03s)
=== RUN   TestAccConnectionOAuth2
--- PASS: TestAccConnectionOAuth2 (3.75s)
=== RUN   TestAccConnectionWithEnbledClients
--- PASS: TestAccConnectionWithEnbledClients (14.90s)
=== RUN   TestAccConnectionSMS
--- PASS: TestAccConnectionSMS (1.88s)
=== RUN   TestAccConnectionEmail
--- PASS: TestAccConnectionEmail (3.60s)
=== RUN   TestAccConnectionSalesforce
--- PASS: TestAccConnectionSalesforce (1.73s)
=== RUN   TestAccConnectionGoogleOAuth2
--- PASS: TestAccConnectionGoogleOAuth2 (1.81s)
=== RUN   TestAccConnectionFacebook
--- PASS: TestAccConnectionFacebook (9.92s)
=== RUN   TestAccConnectionApple
--- PASS: TestAccConnectionApple (3.77s)
=== RUN   TestAccConnectionLinkedin
--- PASS: TestAccConnectionLinkedin (3.36s)
=== RUN   TestAccConnectionGitHub
--- PASS: TestAccConnectionGitHub (2.52s)
=== RUN   TestAccConnectionWindowslive
--- PASS: TestAccConnectionWindowslive (4.24s)
=== RUN   TestAccConnectionConfiguration
--- PASS: TestAccConnectionConfiguration (3.60s)
=== RUN   TestConnectionInstanceStateUpgradeV0
=== RUN   TestConnectionInstanceStateUpgradeV0/Empty
=== RUN   TestConnectionInstanceStateUpgradeV0/Zero
=== RUN   TestConnectionInstanceStateUpgradeV0/NonZero
=== RUN   TestConnectionInstanceStateUpgradeV0/Invalid
--- PASS: TestConnectionInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV0/Empty (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV0/Zero (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV0/NonZero (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV0/Invalid (0.00s)
=== RUN   TestConnectionInstanceStateUpgradeV1
=== RUN   TestConnectionInstanceStateUpgradeV1/Only_Min
=== RUN   TestConnectionInstanceStateUpgradeV1/Min_and_Max
--- PASS: TestConnectionInstanceStateUpgradeV1 (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV1/Only_Min (0.00s)
    --- PASS: TestConnectionInstanceStateUpgradeV1/Min_and_Max (0.00s)
=== RUN   TestAccConnectionSAML
--- PASS: TestAccConnectionSAML (4.12s)
=== RUN   TestAccCustomDomain
--- PASS: TestAccCustomDomain (11.52s)
=== RUN   TestAccEmailTemplate
--- PASS: TestAccEmailTemplate (2.72s)
=== RUN   TestAccEmail
--- PASS: TestAccEmail (5.44s)
=== RUN   TestAccGlobalClient
--- PASS: TestAccGlobalClient (11.27s)
=== RUN   TestAccGuardian
--- PASS: TestAccGuardian (57.34s)
=== RUN   TestAccHook
--- PASS: TestAccHook (2.16s)
=== RUN   TestAccHookSecrets
--- PASS: TestAccHookSecrets (13.00s)
=== RUN   TestHookNameRegexp
--- PASS: TestHookNameRegexp (0.00s)
=== RUN   TestAccLogStreamHTTP
--- PASS: TestAccLogStreamHTTP (4.79s)
=== RUN   TestAccLogStreamEventBridge
--- PASS: TestAccLogStreamEventBridge (6.93s)
=== RUN   TestAccLogStreamEventGrid
    resource_auth0_log_stream_test.go:201: this test requires an active subscription
--- SKIP: TestAccLogStreamEventGrid (0.00s)
=== RUN   TestAccLogStreamDatadog
--- PASS: TestAccLogStreamDatadog (9.68s)
=== RUN   TestAccLogStreamSplunk
--- PASS: TestAccLogStreamSplunk (4.41s)
=== RUN   TestAccLogStreamSumo
--- PASS: TestAccLogStreamSumo (3.19s)
=== RUN   TestAccOrganization
--- PASS: TestAccOrganization (9.94s)
=== RUN   TestAccPrompt
--- PASS: TestAccPrompt (2.71s)
=== RUN   TestAccResourceServer
--- PASS: TestAccResourceServer (3.13s)
=== RUN   TestAccRole
--- PASS: TestAccRole (16.80s)
=== RUN   TestAccRolePermissions
--- PASS: TestAccRolePermissions (5.53s)
=== RUN   TestAccRuleConfig
--- PASS: TestAccRuleConfig (11.07s)
=== RUN   TestAccRule
--- PASS: TestAccRule (2.16s)
=== RUN   TestRuleNameRegexp
--- PASS: TestRuleNameRegexp (0.00s)
=== RUN   TestAccTenant
--- PASS: TestAccTenant (3.41s)
=== RUN   TestAccUserMissingRequiredParams
--- PASS: TestAccUserMissingRequiredParams (0.02s)
=== RUN   TestAccUser
--- PASS: TestAccUser (21.64s)
=== RUN   TestAccUserIssue218
--- PASS: TestAccUserIssue218 (9.10s)
=== RUN   TestAccUserChangeUsername
--- PASS: TestAccUserChangeUsername (5.35s)
=== RUN   TestMapData
=== RUN   TestMapData/GetOk
=== RUN   TestMapData/GetOkExists
--- PASS: TestMapData (0.00s)
    --- PASS: TestMapData/GetOk (0.00s)
    --- PASS: TestMapData/GetOkExists (0.00s)
=== RUN   TestJSON
--- PASS: TestJSON (0.00s)
=== RUN   TestIsNil
--- PASS: TestIsNil (0.00s)
PASS
coverage: 79.7% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0     352.786s        coverage: 79.7% of statements
?       github.com/alexkappa/terraform-provider-auth0/auth0/internal/debug      [no test files]
=== RUN   TestStringKey
=== RUN   TestStringKey/Bar
=== RUN   TestStringKey/Foo
--- PASS: TestStringKey (0.00s)
    --- PASS: TestStringKey/Bar (0.00s)
    --- PASS: TestStringKey/Foo (0.00s)
PASS
coverage: 71.4% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0/internal/hash       0.009s  coverage: 71.4% of statements
=== RUN   TestString
--- PASS: TestString (0.00s)
=== RUN   TestTemplate
--- PASS: TestTemplate (0.00s)
PASS
coverage: 75.0% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0/internal/random     0.012s  coverage: 75.0% of statements
=== RUN   TestIsURLWithNoFragment
--- PASS: TestIsURLWithNoFragment (0.00s)
PASS
coverage: 52.9% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0/internal/validation 0.004s  coverage: 52.9% of statements
?       github.com/alexkappa/terraform-provider-auth0/version   [no test files]
...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->