### PR TITLE
fixed password typo in documentation

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -99,7 +99,7 @@ With the `auth0` connection strategy, `options` supports the following arguments
 
 #### Password Dictionary
 
-`passsword_dictionary` supports the following arguments:
+`password_dictionary` supports the following arguments:
 
 * `enable` - (Optional) Indicates whether the password dictionary check is enabled for this connection.
 * `dictionary` - (Optional) Customized contents of the password dictionary. By default, the password dictionary contains a list of the [10,000 most common passwords](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/10k-most-common.txt); your customized content is used in addition to the default password dictionary. Matching is not case-sensitive.


### PR DESCRIPTION
fixed password typo (was passsword)

### Proposed Changes

* Fixes a typo in connection documentation


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->