### PR TITLE
add support for Management API tokens

### DIFF
--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -38,7 +38,7 @@ func Provider() *schema.Provider {
 			"api_token": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("api_token", nil),
+				DefaultFunc:   schema.EnvDefaultFunc("AUTH0_API_TOKEN", nil),
 				ConflictsWith: []string{"client_id", "client_secret"},
 			},
 			"debug": {

--- a/auth0/provider_test.go
+++ b/auth0/provider_test.go
@@ -114,6 +114,12 @@ func TestProvider_configValidation(t *testing.T) {
 			environment:    map[string]string{},
 			expectedErrors: nil,
 		},
+		{
+			name:           "valid auth0 token from environment",
+			resourceConfig: map[string]interface{}{"domain": "valid_domain"},
+			environment:    map[string]string{"AUTH0_API_TOKEN": "test"},
+			expectedErrors: nil,
+		},
 	}
 
 	for _, test := range testCases {

--- a/auth0/provider_test.go
+++ b/auth0/provider_test.go
@@ -1,12 +1,15 @@
 package auth0
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/stretchr/testify/assert"
 
 	"gopkg.in/auth0.v5/management"
 )
@@ -69,5 +72,68 @@ func TestProvider_debugDefaults(t *testing.T) {
 		if debug.(bool) != expected {
 			t.Fatalf("Expected debug to be %v, but got %v", expected, debug)
 		}
+	}
+}
+
+func TestProvider_configValidation(t *testing.T) {
+	testCases := []struct {
+		name           string
+		environment    map[string]string
+		resourceConfig map[string]interface{}
+		expectedErrors []error
+	}{
+		{
+			name:           "missing client id",
+			environment:    map[string]string{"AUTH0_DOMAIN": "test", "AUTH0_CLIENT_SECRET": "test"},
+			expectedErrors: []error{errors.New("\"client_secret\": all of `client_id,client_secret` must be specified")},
+		},
+		{
+			name:           "missing client secret",
+			environment:    map[string]string{"AUTH0_DOMAIN": "test", "AUTH0_CLIENT_ID": "test"},
+			expectedErrors: []error{errors.New("\"client_id\": all of `client_id,client_secret` must be specified")},
+		},
+		{
+			name:           "conflicting auth0 client and management token without domain",
+			resourceConfig: map[string]interface{}{"client_id": "test", "client_secret": "test", "auth0_token": "test"},
+			environment:    map[string]string{},
+			expectedErrors: []error{
+				errors.New("\"domain\": required field is not set"),
+				errors.New("\"client_id\": conflicts with auth0_token"),
+				errors.New("\"client_secret\": conflicts with auth0_token"),
+				errors.New("\"auth0_token\": conflicts with client_id"),
+			},
+		},
+		{
+			name:           "valid auth0 client",
+			resourceConfig: map[string]interface{}{"domain": "valid_domain", "client_id": "test", "client_secret": "test"},
+			environment:    map[string]string{},
+			expectedErrors: nil,
+		},
+		{
+			name:           "valid auth0 token",
+			resourceConfig: map[string]interface{}{"domain": "valid_domain", "auth0_token": "test"},
+			environment:    map[string]string{},
+			expectedErrors: nil,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			for k, v := range test.environment {
+				os.Unsetenv(k)
+				os.Setenv(k, v)
+			}
+
+			c := terraform.NewResourceConfigRaw(test.resourceConfig)
+			p := Provider()
+
+			r, errs := p.Validate(c)
+			assert.Equal(t, test.expectedErrors, errs)
+			fmt.Println(r, errs)
+
+			for k := range test.environment {
+				os.Unsetenv(k)
+			}
+		})
 	}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,8 +27,12 @@ provider "auth0" {
 ## Argument Reference
 
 * `domain` - (Required) Your Auth0 domain name. It can also be sourced from the `AUTH0_DOMAIN` environment variable.
-* `client_id` - (Required) Your Auth0 client ID. It can also be sourced from the `AUTH0_CLIENT_ID` environment variable.
-* `client_secret` - (Required) Your Auth0 client secret. It can also be sourced from the `AUTH0_CLIENT_SECRET` environment variable.
+* `client_id` - (Optional) Your Auth0 client ID. It can also be sourced from the `AUTH0_CLIENT_ID` environment variable.
+* `client_secret` - (Optional) Your Auth0 client secret. It can also be sourced from the `AUTH0_CLIENT_SECRET` environment variable.
+* `auth0_token` - (Optional) Your Auth0 [management api access token](https://auth0.com/docs/security/tokens/access-tokens/management-api-access-tokens).
+  It can also be sourced from the `AUTH0_TOKEN` environment variable. Can be
+  used instead of `client_id` + `client_secret`. If both are specified,
+  `management_token` will be used over `client_id` + `client_secret` fields.
 * `debug` - (Optional) Indicates whether or not to turn on debug mode.
 
 ## Environment Variables
@@ -51,3 +55,4 @@ $ terraform plan
 ## Importing resources
 
 To import Auth0 resources, you will need to know their id. You can use the [Auth0 API Explorer](https://auth0.com/docs/api/management/v2) to easily find your resource id.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ provider "auth0" {
 * `domain` - (Required) Your Auth0 domain name. It can also be sourced from the `AUTH0_DOMAIN` environment variable.
 * `client_id` - (Optional) Your Auth0 client ID. It can also be sourced from the `AUTH0_CLIENT_ID` environment variable.
 * `client_secret` - (Optional) Your Auth0 client secret. It can also be sourced from the `AUTH0_CLIENT_SECRET` environment variable.
-* `auth0_token` - (Optional) Your Auth0 [management api access token](https://auth0.com/docs/security/tokens/access-tokens/management-api-access-tokens).
+* `api_token` - (Optional) Your Auth0 [management api access token](https://auth0.com/docs/security/tokens/access-tokens/management-api-access-tokens).
   It can also be sourced from the `AUTH0_TOKEN` environment variable. Can be
   used instead of `client_id` + `client_secret`. If both are specified,
   `management_token` will be used over `client_id` + `client_secret` fields.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ provider "auth0" {
 * `client_id` - (Optional) Your Auth0 client ID. It can also be sourced from the `AUTH0_CLIENT_ID` environment variable.
 * `client_secret` - (Optional) Your Auth0 client secret. It can also be sourced from the `AUTH0_CLIENT_SECRET` environment variable.
 * `api_token` - (Optional) Your Auth0 [management api access token](https://auth0.com/docs/security/tokens/access-tokens/management-api-access-tokens).
-  It can also be sourced from the `AUTH0_TOKEN` environment variable. Can be
+  It can also be sourced from the `AUTH0_API_TOKEN` environment variable. Can be
   used instead of `client_id` + `client_secret`. If both are specified,
   `management_token` will be used over `client_id` + `client_secret` fields.
 * `debug` - (Optional) Indicates whether or not to turn on debug mode.


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* add support for [Management API tokens](https://auth0.com/docs/security/tokens/access-tokens/management-api-access-tokens) for authenticating to auth0

#### Acceptance Test Output

I ran the acceptance tests using `AUTH0_MANAGEMENT_TOKENS` tokens so I'm not sure if the test failures are flaky tests, problems with using a management token, or expected behavior.

<details>
  <summary>output</summary>

```
$ make testacc TESTS=TestAccXXX
?   	github.com/alexkappa/terraform-provider-auth0	[no test files]
=== RUN   TestAccAction
--- PASS: TestAccAction (5.20s)
=== RUN   TestAccBranding
--- PASS: TestAccBranding (10.02s)
=== RUN   TestAccClientGrant
--- PASS: TestAccClientGrant (27.15s)
=== RUN   TestAccClient
--- PASS: TestAccClient (1.64s)
=== RUN   TestAccClientZeroValueCheck
--- PASS: TestAccClientZeroValueCheck (10.03s)
=== RUN   TestAccClientRotateSecret
--- PASS: TestAccClientRotateSecret (2.57s)
=== RUN   TestAccClientInitiateLoginUri
--- PASS: TestAccClientInitiateLoginUri (0.08s)
=== RUN   TestAccClientJwtScopes
--- PASS: TestAccClientJwtScopes (8.75s)
=== RUN   TestAccClientMobile
--- PASS: TestAccClientMobile (2.23s)
=== RUN   TestAccClientMobileValidationError
--- PASS: TestAccClientMobileValidationError (0.02s)
=== RUN   TestAccConnection
--- PASS: TestAccConnection (8.70s)
=== RUN   TestAccConnectionAD
--- PASS: TestAccConnectionAD (1.21s)
=== RUN   TestAccConnectionAzureAD
--- PASS: TestAccConnectionAzureAD (2.07s)
=== RUN   TestAccConnectionOIDC
--- PASS: TestAccConnectionOIDC (8.88s)
=== RUN   TestAccConnectionOAuth2
--- PASS: TestAccConnectionOAuth2 (2.87s)
=== RUN   TestAccConnectionWithEnbledClients
--- PASS: TestAccConnectionWithEnbledClients (14.40s)
=== RUN   TestAccConnectionSMS
--- PASS: TestAccConnectionSMS (1.48s)
=== RUN   TestAccConnectionEmail
--- PASS: TestAccConnectionEmail (8.76s)
=== RUN   TestAccConnectionSalesforce
--- PASS: TestAccConnectionSalesforce (1.58s)
=== RUN   TestAccConnectionGoogleOAuth2
--- PASS: TestAccConnectionGoogleOAuth2 (1.47s)
=== RUN   TestAccConnectionFacebook
--- PASS: TestAccConnectionFacebook (5.30s)
=== RUN   TestAccConnectionApple
--- PASS: TestAccConnectionApple (2.76s)
=== RUN   TestAccConnectionLinkedin
    testing.go:705: Step 1 error: errors during apply:

        Error: request failed: Get "https://<domain>.us.auth0.com/api/v2/connections/con_7yBDenELOvPA6LaK": read tcp [2601:282:4700:e370:926c:69dd:5f5e:8392]:44394->[2606:4700::6810:abfd]:443: read: connection reset by peer

          on /run/user/1000/tf-test985585983/main.tf line 3:
          (source code not available)


--- FAIL: TestAccConnectionLinkedin (8.50s)
=== RUN   TestAccConnectionGitHub
--- PASS: TestAccConnectionGitHub (1.28s)
=== RUN   TestAccConnectionWindowslive
--- PASS: TestAccConnectionWindowslive (2.61s)
=== RUN   TestAccConnectionConfiguration
--- PASS: TestAccConnectionConfiguration (9.01s)
=== RUN   TestAccConnectionSAML
--- PASS: TestAccConnectionSAML (2.06s)
=== RUN   TestAccCustomDomain
    testing.go:705: Step 0 error: errors during apply:

        Error: 403 Forbidden: The account is not allowed to perform this operation, please contact our support team

          on /run/user/1000/tf-test015103310/main.tf line 3:
          (source code not available)


--- FAIL: TestAccCustomDomain (0.26s)
=== RUN   TestAccCustomDomainVerification
    testing.go:705: Step 0 error: errors during apply:

        Error: 403 Forbidden: The account is not allowed to perform this operation, please contact our support team

          on /run/user/1000/tf-test956613040/main.tf line 10:
          (source code not available)


--- FAIL: TestAccCustomDomainVerification (0.26s)
=== RUN   TestAccEmailTemplate
--- PASS: TestAccEmailTemplate (8.27s)
=== RUN   TestAccEmail
--- PASS: TestAccEmail (9.81s)
=== RUN   TestAccGlobalClient
--- PASS: TestAccGlobalClient (3.56s)
=== RUN   TestAccGuardian
--- PASS: TestAccGuardian (65.38s)
=== RUN   TestAccHook
--- PASS: TestAccHook (1.40s)
=== RUN   TestAccHookSecrets
--- PASS: TestAccHookSecrets (11.78s)
=== RUN   TestAccLogStreamHTTP
--- PASS: TestAccLogStreamHTTP (9.47s)
=== RUN   TestAccLogStreamEventBridge
--- PASS: TestAccLogStreamEventBridge (11.41s)
=== RUN   TestAccLogStreamEventGrid
    resource_auth0_log_stream_test.go:201: this test requires an active subscription
--- SKIP: TestAccLogStreamEventGrid (0.00s)
=== RUN   TestAccLogStreamDatadog
--- PASS: TestAccLogStreamDatadog (3.12s)
=== RUN   TestAccLogStreamSplunk
--- PASS: TestAccLogStreamSplunk (8.50s)
=== RUN   TestAccLogStreamSumo
--- PASS: TestAccLogStreamSumo (2.04s)
=== RUN   TestAccOrganization
--- PASS: TestAccOrganization (32.57s)
=== RUN   TestAccPrompt
--- PASS: TestAccPrompt (1.67s)
=== RUN   TestAccResourceServer
--- PASS: TestAccResourceServer (8.57s)
=== RUN   TestAccRole
--- PASS: TestAccRole (11.74s)
=== RUN   TestAccRolePermissions
--- PASS: TestAccRolePermissions (11.31s)
=== RUN   TestAccRuleConfig
--- PASS: TestAccRuleConfig (9.53s)
=== RUN   TestAccRule
--- PASS: TestAccRule (1.04s)
=== RUN   TestAccTenant
--- PASS: TestAccTenant (1.86s)
=== RUN   TestAccTriggerBinding
--- PASS: TestAccTriggerBinding (16.88s)
=== RUN   TestAccUserMissingRequiredParams
--- PASS: TestAccUserMissingRequiredParams (0.01s)
=== RUN   TestAccUser
    testing.go:705: Step 0 error: errors during apply:

        Error: 400 Bad Request: Cannot set username for connection without requires_username

          on /run/user/1000/tf-test431826711/main.tf line 3:
          (source code not available)


--- FAIL: TestAccUser (0.31s)
=== RUN   TestAccUserIssue218
    testing.go:705: Step 0 error: errors during apply:

        Error: 400 Bad Request: Cannot set username for connection without requires_username

          on /run/user/1000/tf-test712170849/main.tf line 3:
          (source code not available)


--- FAIL: TestAccUserIssue218 (0.21s)
=== RUN   TestAccUserChangeUsername
    testing.go:705: Step 0 error: errors during apply:

        Error: 400 Bad Request: Cannot set username for connection without requires_username

          on /run/user/1000/tf-test910243899/main.tf line 3:
          (source code not available)


--- FAIL: TestAccUserChangeUsername (0.30s)
FAIL
coverage: 70.2% of statements
FAIL	github.com/alexkappa/terraform-provider-auth0/auth0	381.927s
?   	github.com/alexkappa/terraform-provider-auth0/auth0/internal/debug	[no test files]
?   	github.com/alexkappa/terraform-provider-auth0/auth0/internal/digitalocean	[no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/hash	0.013s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/random	0.020s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/validation	0.002s	coverage: 0.0% of statements [no tests to run]
?   	github.com/alexkappa/terraform-provider-auth0/version	[no test files]
FAIL
make: *** [GNUmakefile:26: testacc] Error 1
```
</details>
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->