### PR TITLE
Add Signing Keys to clients

### DIFF
--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -690,7 +690,7 @@ func expandClient(d *schema.ResourceData) *management.Client {
 		InitiateLoginURI:               String(d, "initiate_login_uri"),
 	}
 
-	if l := List(d, "signing_keys", IsNewResource()); l != nil {
+	if l := List(d, "signing_keys", IsNewResource(), HasChange()); l != nil {
 		c.SigningKeys = []map[string]string{}
 		for _, v := range l.List() {
 			mapString := make(map[string]string)

--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -584,6 +584,7 @@ func readClient(d *schema.ResourceData, m interface{}) error {
 	d.Set("allowed_origins", c.AllowedOrigins)
 	d.Set("allowed_clients", c.AllowedClients)
 	d.Set("grant_types", c.GrantTypes)
+	d.Set("signing_keys", c.SigningKeys)
 	d.Set("organization_usage", c.OrganizationUsage)
 	d.Set("organization_require_behavior", c.OrganizationRequireBehavior)
 	d.Set("web_origins", c.WebOrigins)

--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -1,6 +1,7 @@
 package auth0
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -543,6 +544,27 @@ func newClient() *schema.Resource {
 					},
 				},
 			},
+			"signing_keys": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cert": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pkcs7": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subject": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -666,6 +688,20 @@ func expandClient(d *schema.ResourceData) *management.Client {
 		FormTemplate:                   String(d, "form_template"),
 		TokenEndpointAuthMethod:        String(d, "token_endpoint_auth_method"),
 		InitiateLoginURI:               String(d, "initiate_login_uri"),
+	}
+
+	if l := List(d, "signing_keys", IsNewResource()); l != nil {
+		c.SigningKeys = []map[string]string{}
+		for _, v := range l.List() {
+			mapString := make(map[string]string)
+
+			for key, value := range v.(map[string]interface{}) {
+				strKey := fmt.Sprintf("%v", key)
+				strValue := fmt.Sprintf("%v", value)
+				mapString[strKey] = strValue
+			}
+			c.SigningKeys = append(c.SigningKeys, mapString)
+		}
 	}
 
 	List(d, "refresh_token", IsNewResource(), HasChange()).Elem(func(d ResourceData) {

--- a/auth0/resource_auth0_client_test.go
+++ b/auth0/resource_auth0_client_test.go
@@ -447,3 +447,44 @@ resource "auth0_client" "my_client" {
   }
 }
 `
+
+func TestAccClientSigningKeys(t *testing.T) {
+	rand := random.String(6)
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: random.Template(testAccClientSigningKeysCreate, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_client.my_client", "name", "Acceptance Test - Signing Keys - {{.random}}", rand),
+					resource.TestCheckResourceAttrSet("auth0_client.my_client", "signing_keys.0.cert"),
+				),
+			},
+			{
+				Config: random.Template(testAccClientSigningKeysUpdate, rand),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("auth0_client.my_client", "signing_keys.0.cert"),
+				),
+			},
+		},
+	})
+}
+
+const testAccClientSigningKeysCreate = `
+
+resource "auth0_client" "my_client" {
+  name = "Acceptance Test - Signing Keys - {{.random}}"
+  is_first_party = false
+}
+`
+
+const testAccClientSigningKeysUpdate = `
+
+resource "auth0_client" "my_client" {
+  name = "Acceptance Test - Signing Keys - {{.random}}"
+  is_first_party = true
+}
+`


### PR DESCRIPTION
### Proposed Changes

* Added `signing_keys` to `readClient`


SigningKeys is already supported in [management client](https://github.com/go-auth0/auth0/blob/master/management/client.go), so exposing this.

#### Acceptance Test Output

```
╭─    ~/Development/terraform-provider-auth0  on   signing_keys !1                                                                                                                     ✔  base   at 04:11:39 PM 
╰─ make testacc TESTS=TestAccClient
==> Checking that code complies with gofmt requirements...
?   	github.com/alexkappa/terraform-provider-auth0	[no test files]
=== RUN   TestAccClientGrant
--- PASS: TestAccClientGrant (26.22s)
=== RUN   TestAccClient
--- PASS: TestAccClient (1.39s)
=== RUN   TestAccClientZeroValueCheck
--- PASS: TestAccClientZeroValueCheck (9.45s)
=== RUN   TestAccClientRotateSecret
--- PASS: TestAccClientRotateSecret (2.34s)
=== RUN   TestAccClientInitiateLoginUri
--- PASS: TestAccClientInitiateLoginUri (0.05s)
=== RUN   TestAccClientJwtScopes
--- PASS: TestAccClientJwtScopes (8.59s)
=== RUN   TestAccClientMobile
--- PASS: TestAccClientMobile (2.39s)
=== RUN   TestAccClientMobileValidationError
--- PASS: TestAccClientMobileValidationError (0.01s)
PASS
coverage: 18.4% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0	50.728s	coverage: 18.4% of statements
?   	github.com/alexkappa/terraform-provider-auth0/auth0/internal/debug	[no test files]
?   	github.com/alexkappa/terraform-provider-auth0/auth0/internal/digitalocean	[no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/hash	0.227s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/random	0.233s	coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/alexkappa/terraform-provider-auth0/auth0/internal/validation	0.145s	coverage: 0.0% of statements [no tests to run]
?   	github.com/alexkappa/terraform-provider-auth0/version	[no test files]

...
```


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->