### PR TITLE
Added auth0 prompt custom text

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,91 +1,91 @@
 resource/auth0_action:
-  - "**/*action.go"
-  - "**/*action_test.go"
+  - '**/*action.go'
+  - '**/*action_test.go'
 
 resource/auth0_branding:
-  - "**/*branding.go"
-  - "**/*branding_test.go"
+  - '**/*branding.go'
+  - '**/*branding_test.go'
 
 resource/auth0_client:
-  - "**/*client.go"
-  - "**/*client_test.go"
+  - '**/*client.go'
+  - '**/*client_test.go'
 
 resource/auth0_client_grant:
-  - "**/*client_grant.go"
-  - "**/*client_grant_test.go"
+  - '**/*client_grant.go'
+  - '**/*client_grant_test.go'
 
 resource/auth0_connection:
-  - "**/*connection.go"
-  - "**/*connection_test.go"
+  - '**/*connection.go'
+  - '**/*connection_test.go'
 
 resource/auth0_custom_domain:
-  - "**/*custom_domain.go"
-  - "**/*custom_domain_test.go"
+  - '**/*custom_domain.go'
+  - '**/*custom_domain_test.go'
 
 resource/auth0_email:
-  - "**/*email.go"
-  - "**/*email_test.go"
+  - '**/*email.go'
+  - '**/*email_test.go'
 
 resource/auth0_email_template:
-  - "**/*email_template.go"
-  - "**/*email_template_test.go"
+  - '**/*email_template.go'
+  - '**/*email_template_test.go'
 
 resource/auth0_global_client:
-  - "**/*global_client.go"
-  - "**/*global_client_test.go"
+  - '**/*global_client.go'
+  - '**/*global_client_test.go'
 
 resource/auth0_guardian:
-  - "**/*guardian.go"
-  - "**/*guardian_test.go"
+  - '**/*guardian.go'
+  - '**/*guardian_test.go'
 
 resource/auth0_hook:
-  - "**/*hook.go"
-  - "**/*hook_test.go"
+  - '**/*hook.go'
+  - '**/*hook_test.go'
 
 resource/auth0_log_stream:
-  - "**/*log_stream.go"
-  - "**/*log_stream_test.go"
+  - '**/*log_stream.go'
+  - '**/*log_stream_test.go'
 
 resource/auth0_organization:
-  - "**/*organization.go"
-  - "**/*organization_test.go"
+  - '**/*organization.go'
+  - '**/*organization_test.go'
 
 resource/auth0_prompt:
-  - "**/*prompt.go"
-  - "**/*prompt_test.go"
+  - '**/*prompt.go'
+  - '**/*prompt_test.go'
 
 resource/auth0_prompt_custom_text:
-  - "**/*prompt_custom_text.go"
-  - "**/*prompt_custom_text_test.go"
+  - '**/*prompt_custom_text.go'
+  - '**/*prompt_custom_text_test.go'
 
 resource/auth0_resource_server:
-  - "**/*resource_server.go"
-  - "**/*resource_server_test.go"
+  - '**/*resource_server.go'
+  - '**/*resource_server_test.go'
 
 resource/auth0_role:
-  - "**/*role.go"
-  - "**/*role_test.go"
+  - '**/*role.go'
+  - '**/*role_test.go'
 
 resource/auth0_rule:
-  - "**/*rule.go"
-  - "**/*rule_test.go"
+  - '**/*rule.go'
+  - '**/*rule_test.go'
 
 resource/auth0_rule_config:
-  - "**/*rule_config.go"
-  - "**/*rule_config_test.go"
+  - '**/*rule_config.go'
+  - '**/*rule_config_test.go'
 
 resource/auth0_tenant:
-  - "**/*tenant.go"
-  - "**/*tenant_test.go"
+  - '**/*tenant.go'
+  - '**/*tenant_test.go'
 
 resource/auth0_trigger_binding:
-  - "**/*trigger_binding.go"
-  - "**/*trigger_binding_test.go"
+  - '**/*trigger_binding.go'
+  - '**/*trigger_binding_test.go'
 
 resource/auth0_user:
-  - "**/*user.go"
-  - "**/*user_test.go"
+  - '**/*user.go'
+  - '**/*user_test.go'
 
 resource_data:
-  - "**/resource_data.go"
-  - "**/resource_data_test.go"
+  - '**/resource_data.go'
+  - '**/resource_data_test.go'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,87 +1,91 @@
 resource/auth0_action:
-  - '**/*action.go'
-  - '**/*action_test.go'
+  - "**/*action.go"
+  - "**/*action_test.go"
 
 resource/auth0_branding:
-  - '**/*branding.go'
-  - '**/*branding_test.go'
+  - "**/*branding.go"
+  - "**/*branding_test.go"
 
 resource/auth0_client:
-  - '**/*client.go'
-  - '**/*client_test.go'
+  - "**/*client.go"
+  - "**/*client_test.go"
 
 resource/auth0_client_grant:
-  - '**/*client_grant.go'
-  - '**/*client_grant_test.go'
+  - "**/*client_grant.go"
+  - "**/*client_grant_test.go"
 
 resource/auth0_connection:
-  - '**/*connection.go'
-  - '**/*connection_test.go'
+  - "**/*connection.go"
+  - "**/*connection_test.go"
 
 resource/auth0_custom_domain:
-  - '**/*custom_domain.go'
-  - '**/*custom_domain_test.go'
+  - "**/*custom_domain.go"
+  - "**/*custom_domain_test.go"
 
 resource/auth0_email:
-  - '**/*email.go'
-  - '**/*email_test.go'
+  - "**/*email.go"
+  - "**/*email_test.go"
 
 resource/auth0_email_template:
-  - '**/*email_template.go'
-  - '**/*email_template_test.go'
+  - "**/*email_template.go"
+  - "**/*email_template_test.go"
 
 resource/auth0_global_client:
-  - '**/*global_client.go'
-  - '**/*global_client_test.go'
+  - "**/*global_client.go"
+  - "**/*global_client_test.go"
 
 resource/auth0_guardian:
-  - '**/*guardian.go'
-  - '**/*guardian_test.go'
+  - "**/*guardian.go"
+  - "**/*guardian_test.go"
 
 resource/auth0_hook:
-  - '**/*hook.go'
-  - '**/*hook_test.go'
+  - "**/*hook.go"
+  - "**/*hook_test.go"
 
 resource/auth0_log_stream:
-  - '**/*log_stream.go'
-  - '**/*log_stream_test.go'
+  - "**/*log_stream.go"
+  - "**/*log_stream_test.go"
 
 resource/auth0_organization:
-  - '**/*organization.go'
-  - '**/*organization_test.go'
+  - "**/*organization.go"
+  - "**/*organization_test.go"
 
 resource/auth0_prompt:
-  - '**/*prompt.go'
-  - '**/*prompt_test.go'
+  - "**/*prompt.go"
+  - "**/*prompt_test.go"
+
+resource/auth0_prompt_custom_text:
+  - "**/*prompt_custom_text.go"
+  - "**/*prompt_custom_text_test.go"
 
 resource/auth0_resource_server:
-  - '**/*resource_server.go'
-  - '**/*resource_server_test.go'
+  - "**/*resource_server.go"
+  - "**/*resource_server_test.go"
 
 resource/auth0_role:
-  - '**/*role.go'
-  - '**/*role_test.go'
+  - "**/*role.go"
+  - "**/*role_test.go"
 
 resource/auth0_rule:
-  - '**/*rule.go'
-  - '**/*rule_test.go'
+  - "**/*rule.go"
+  - "**/*rule_test.go"
 
 resource/auth0_rule_config:
-  - '**/*rule_config.go'
-  - '**/*rule_config_test.go'
+  - "**/*rule_config.go"
+  - "**/*rule_config_test.go"
 
 resource/auth0_tenant:
-  - '**/*tenant.go'
-  - '**/*tenant_test.go'
+  - "**/*tenant.go"
+  - "**/*tenant_test.go"
 
 resource/auth0_trigger_binding:
-  - '**/*trigger_binding.go'
-  - '**/*trigger_binding_test.go'
+  - "**/*trigger_binding.go"
+  - "**/*trigger_binding_test.go"
 
 resource/auth0_user:
-  - '**/*user.go'
-  - '**/*user_test.go'
+  - "**/*user.go"
+  - "**/*user_test.go"
 
 resource_data:
-  - '**/resource_data.go'
-  - '**/resource_data_test.go'
+  - "**/resource_data.go"
+  - "**/resource_data_test.go"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.26.0
+
+ENHANCEMENTS:
+
+* **New Resource:** `auth0_prompt_custom_text` ([#497](https://github.com/alexkappa/terraform-provider-auth0/pull/497))
+
 ## 0.25.1
 
 ENHANCEMENTS:

--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -56,6 +56,7 @@ func init() {
 			"auth0_rule_config":                newRuleConfig(),
 			"auth0_hook":                       newHook(),
 			"auth0_prompt":                     newPrompt(),
+			"auth0_prompt_custom_text":         newPromptCustomText(),
 			"auth0_email":                      newEmail(),
 			"auth0_email_template":             newEmailTemplate(),
 			"auth0_user":                       newUser(),

--- a/auth0/resource_auth0_prompt_custom_text.go
+++ b/auth0/resource_auth0_prompt_custom_text.go
@@ -62,12 +62,15 @@ func newPromptCustomText() *schema.Resource {
 
 func importPromptCustomText(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	prompt, language, err := getPromptAndLanguage(d)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 
 	d.SetId(d.Id())
 	d.Set("prompt", prompt)
 	d.Set("language", language)
 
-	return []*schema.ResourceData{d}, err
+	return []*schema.ResourceData{d}, nil
 }
 
 func createPromptCustomText(d *schema.ResourceData, m interface{}) error {

--- a/auth0/resource_auth0_prompt_custom_text.go
+++ b/auth0/resource_auth0_prompt_custom_text.go
@@ -26,7 +26,7 @@ var (
 		"hu", "id", "is", "it", "ja", "ko", "lt", "lv", "nb", "nl", "pl", "pt", "pt-BR", "pt-PT", "ro", "ru", "sk",
 		"sl", "sr", "sv", "th", "tr", "uk", "vi", "zh-CN", "zh-TW",
 	}
-	errEmptyPromptCustomTextID = fmt.Errorf("ID cannot be empty")
+	errEmptyPromptCustomTextID         = fmt.Errorf("ID cannot be empty")
 	errInvalidPromptCustomTextIDFormat = fmt.Errorf("ID must be formated as prompt:language")
 )
 
@@ -121,6 +121,7 @@ func updatePromptCustomText(d *schema.ResourceData, m interface{}) error {
 
 func deletePromptCustomText(d *schema.ResourceData, m interface{}) error {
 	d.SetId("")
+	d.Set("body", "{}")
 	return nil
 }
 

--- a/auth0/resource_auth0_prompt_custom_text.go
+++ b/auth0/resource_auth0_prompt_custom_text.go
@@ -120,8 +120,11 @@ func updatePromptCustomText(d *schema.ResourceData, m interface{}) error {
 }
 
 func deletePromptCustomText(d *schema.ResourceData, m interface{}) error {
-	d.SetId("")
 	d.Set("body", "{}")
+
+	updatePromptCustomText(d, m)
+
+	d.SetId("")
 	return nil
 }
 

--- a/auth0/resource_auth0_prompt_custom_text.go
+++ b/auth0/resource_auth0_prompt_custom_text.go
@@ -1,0 +1,151 @@
+package auth0
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"gopkg.in/auth0.v5/management"
+)
+
+func newPromptCustomText() *schema.Resource {
+
+	return &schema.Resource{
+
+		Create: createPromptCustomText,
+		Read:   readPromptCustomText,
+		Update: updatePromptCustomText,
+		Delete: deletePromptCustomText,
+		Importer: &schema.ResourceImporter{
+			State: importPromptCustomText,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"prompt": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"login", "login-id", "login-password", "login-email-verification", "signup", "signup-id", "signup-password", "reset-password", "consent", "mfa-push",
+					"mfa-otp", "mfa-voice", "mfa-phone", "mfa-webauthn", "mfa-sms", "mfa-email", "mfa-recovery-code", "mfa", "status", "device-flow", "email-verification",
+					"email-otp-challenge", "organizations", "invitation", "common",
+				}, false),
+			},
+			"language": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ar", "bg", "bs", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "fr-CA", "fr-FR", "he", "hi", "hr", "hu", "id", "is", "it",
+					"ja", "ko", "lt", "lv", "nb", "nl", "pl", "pt", "pt-BR", "pt-PT", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "vi", "zh-CN", "zh-TW",
+				}, false),
+			},
+			"body": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validation.ValidateJsonString,
+				DiffSuppressFunc: structure.SuppressJsonDiff,
+			},
+		},
+	}
+}
+
+func importPromptCustomText(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	prompt, language, err := getPromptAndLanguage(d)
+	d.SetId(d.Id())
+	d.Set("prompt", prompt)
+	d.Set("language", language)
+
+	return []*schema.ResourceData{d}, err
+}
+
+func createPromptCustomText(d *schema.ResourceData, m interface{}) error {
+	d.SetId(d.Get("prompt").(string) + ":" + d.Get("language").(string))
+	return updatePromptCustomText(d, m)
+}
+
+func getPromptAndLanguage(d *schema.ResourceData) (string, string, error) {
+	if d.Id() == "" {
+		return "", "", fmt.Errorf("ID cannot be empty")
+	}
+
+	if !strings.Contains(d.Id(), ":") {
+		return "", "", fmt.Errorf("ID must be formated as prompt:language")
+	}
+
+	s := strings.Split(d.Id(), ":")
+	// Validate that this is an ID by making sure it is size 2
+	if len(s) != 2 {
+		return "", "", fmt.Errorf("ID must have lenght of 2")
+	}
+
+	return s[0], s[1], nil
+}
+
+func marshalCustomTextBody(b map[string]interface{}) (string, error) {
+	bodyBytes, err := json.Marshal(b)
+	if err != nil {
+		return "", fmt.Errorf("Failed to serialize the custom texts to JSON: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, []byte(bodyBytes), "", "    "); err != nil {
+		return "", fmt.Errorf("Failed to format the custom texts JSON: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func readPromptCustomText(d *schema.ResourceData, m interface{}) error {
+	api := m.(*management.Management)
+	p, err := api.Prompt.CustomText(d.Get("prompt").(string), d.Get("language").(string))
+	if err != nil {
+		if mErr, ok := err.(management.Error); ok {
+			if mErr.Status() == http.StatusNotFound {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	bodyStr, err := marshalCustomTextBody(p)
+	if err != nil {
+		return err
+	}
+
+	d.Set("body", bodyStr)
+	return nil
+}
+
+func updatePromptCustomText(d *schema.ResourceData, m interface{}) error {
+	api := m.(*management.Management)
+
+	prompt, language, err := getPromptAndLanguage(d)
+
+	if err != nil {
+		return err
+	}
+
+	if d.Get("body").(string) != "" {
+		var body map[string]interface{}
+		if err := json.Unmarshal([]byte(d.Get("body").(string)), &body); err != nil {
+			return err
+		}
+
+		err := api.Prompt.SetCustomText(prompt, language, body)
+		if err != nil {
+			return err
+		}
+	}
+
+	return readPromptCustomText(d, m)
+}
+
+func deletePromptCustomText(d *schema.ResourceData, m interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/auth0/resource_auth0_prompt_custom_text.go
+++ b/auth0/resource_auth0_prompt_custom_text.go
@@ -14,10 +14,24 @@ import (
 	"gopkg.in/auth0.v5/management"
 )
 
+var (
+	availablePrompts = []string{
+		"login", "login-id", "login-password", "login-email-verification", "signup", "signup-id", "signup-password",
+		"reset-password", "consent", "mfa-push", "mfa-otp", "mfa-voice", "mfa-phone", "mfa-webauthn", "mfa-sms",
+		"mfa-email", "mfa-recovery-code", "mfa", "status", "device-flow", "email-verification", "email-otp-challenge",
+		"organizations", "invitation", "common",
+	}
+	availableLanguages = []string{
+		"ar", "bg", "bs", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "fr-CA", "fr-FR", "he", "hi", "hr",
+		"hu", "id", "is", "it", "ja", "ko", "lt", "lv", "nb", "nl", "pl", "pt", "pt-BR", "pt-PT", "ro", "ru", "sk",
+		"sl", "sr", "sv", "th", "tr", "uk", "vi", "zh-CN", "zh-TW",
+	}
+	errEmptyPromptCustomTextID = fmt.Errorf("ID cannot be empty")
+	errInvalidPromptCustomTextIDFormat = fmt.Errorf("ID must be formated as prompt:language")
+)
+
 func newPromptCustomText() *schema.Resource {
-
 	return &schema.Resource{
-
 		Create: createPromptCustomText,
 		Read:   readPromptCustomText,
 		Update: updatePromptCustomText,
@@ -25,37 +39,30 @@ func newPromptCustomText() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: importPromptCustomText,
 		},
-
 		Schema: map[string]*schema.Schema{
 			"prompt": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"login", "login-id", "login-password", "login-email-verification", "signup", "signup-id", "signup-password", "reset-password", "consent", "mfa-push",
-					"mfa-otp", "mfa-voice", "mfa-phone", "mfa-webauthn", "mfa-sms", "mfa-email", "mfa-recovery-code", "mfa", "status", "device-flow", "email-verification",
-					"email-otp-challenge", "organizations", "invitation", "common",
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(availablePrompts, false),
 			},
 			"language": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"ar", "bg", "bs", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "fr-CA", "fr-FR", "he", "hi", "hr", "hu", "id", "is", "it",
-					"ja", "ko", "lt", "lv", "nb", "nl", "pl", "pt", "pt-BR", "pt-PT", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "vi", "zh-CN", "zh-TW",
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(availableLanguages, false),
 			},
 			"body": {
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateFunc:     validation.ValidateJsonString,
+				ValidateFunc:     validation.StringIsJSON,
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
 		},
 	}
 }
 
-func importPromptCustomText(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func importPromptCustomText(d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	prompt, language, err := getPromptAndLanguage(d)
+
 	d.SetId(d.Id())
 	d.Set("prompt", prompt)
 	d.Set("language", language)
@@ -68,40 +75,9 @@ func createPromptCustomText(d *schema.ResourceData, m interface{}) error {
 	return updatePromptCustomText(d, m)
 }
 
-func getPromptAndLanguage(d *schema.ResourceData) (string, string, error) {
-	if d.Id() == "" {
-		return "", "", fmt.Errorf("ID cannot be empty")
-	}
-
-	if !strings.Contains(d.Id(), ":") {
-		return "", "", fmt.Errorf("ID must be formated as prompt:language")
-	}
-
-	s := strings.Split(d.Id(), ":")
-	// Validate that this is an ID by making sure it is size 2
-	if len(s) != 2 {
-		return "", "", fmt.Errorf("ID must have lenght of 2")
-	}
-
-	return s[0], s[1], nil
-}
-
-func marshalCustomTextBody(b map[string]interface{}) (string, error) {
-	bodyBytes, err := json.Marshal(b)
-	if err != nil {
-		return "", fmt.Errorf("Failed to serialize the custom texts to JSON: %w", err)
-	}
-
-	var buf bytes.Buffer
-	if err := json.Indent(&buf, []byte(bodyBytes), "", "    "); err != nil {
-		return "", fmt.Errorf("Failed to format the custom texts JSON: %w", err)
-	}
-	return buf.String(), nil
-}
-
 func readPromptCustomText(d *schema.ResourceData, m interface{}) error {
 	api := m.(*management.Management)
-	p, err := api.Prompt.CustomText(d.Get("prompt").(string), d.Get("language").(string))
+	customText, err := api.Prompt.CustomText(d.Get("prompt").(string), d.Get("language").(string))
 	if err != nil {
 		if mErr, ok := err.(management.Error); ok {
 			if mErr.Status() == http.StatusNotFound {
@@ -112,20 +88,18 @@ func readPromptCustomText(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	bodyStr, err := marshalCustomTextBody(p)
+	body, err := marshalCustomTextBody(customText)
 	if err != nil {
 		return err
 	}
 
-	d.Set("body", bodyStr)
+	d.Set("body", body)
 	return nil
 }
 
 func updatePromptCustomText(d *schema.ResourceData, m interface{}) error {
 	api := m.(*management.Management)
-
 	prompt, language, err := getPromptAndLanguage(d)
-
 	if err != nil {
 		return err
 	}
@@ -148,4 +122,37 @@ func updatePromptCustomText(d *schema.ResourceData, m interface{}) error {
 func deletePromptCustomText(d *schema.ResourceData, m interface{}) error {
 	d.SetId("")
 	return nil
+}
+
+func getPromptAndLanguage(d *schema.ResourceData) (string, string, error) {
+	rawID := d.Id()
+	if rawID == "" {
+		return "", "", errEmptyPromptCustomTextID
+	}
+
+	if !strings.Contains(rawID, ":") {
+		return "", "", errInvalidPromptCustomTextIDFormat
+	}
+
+	idPair := strings.Split(rawID, ":")
+	if len(idPair) != 2 {
+		return "", "", errInvalidPromptCustomTextIDFormat
+	}
+
+	return idPair[0], idPair[1], nil
+}
+
+func marshalCustomTextBody(b map[string]interface{}) (string, error) {
+	bodyBytes, err := json.Marshal(b)
+	if err != nil {
+		return "", fmt.Errorf("Failed to serialize the custom texts to JSON: %w", err)
+	}
+
+	var buffer bytes.Buffer
+	const jsonIndentation = "    "
+	if err := json.Indent(&buffer, bodyBytes, "", jsonIndentation); err != nil {
+		return "", fmt.Errorf("Failed to format the custom texts JSON: %w", err)
+	}
+
+	return buffer.String(), nil
 }

--- a/auth0/resource_auth0_prompt_custom_text.go
+++ b/auth0/resource_auth0_prompt_custom_text.go
@@ -122,7 +122,9 @@ func updatePromptCustomText(d *schema.ResourceData, m interface{}) error {
 func deletePromptCustomText(d *schema.ResourceData, m interface{}) error {
 	d.Set("body", "{}")
 
-	updatePromptCustomText(d, m)
+	if err := updatePromptCustomText(d, m); err != nil {
+		return err
+	}
 
 	d.SetId("")
 	return nil

--- a/auth0/resource_auth0_prompt_custom_text_test.go
+++ b/auth0/resource_auth0_prompt_custom_text_test.go
@@ -1,0 +1,53 @@
+package auth0
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccPromptCustomText(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPromptCustomTextCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "prompt", "login"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "login", "en"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "body", "{\"login\": { \"alertListTitle\": \"Alerts\", \"buttonText\": \"Continue\"}}"),
+				),
+			},
+			{
+				Config: testAccPromptCustomTextUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "prompt", "login"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "login", "en"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "body", "{\"login\": { \"alertListTitle\": \"Alerts\", \"buttonText\": \"Continue to Login\"}}"),
+				),
+			},
+		},
+	})
+}
+
+const testAccPromptCustomTextCreate = `
+
+resource "auth0_prompt_custom_text" "prompt_custom_text" {
+  prompt = "login"
+  language = "en"
+  body = "{\"login\": { \"alertListTitle\": \"Alerts\", \"buttonText\": \"Continue\"}}""
+}
+`
+
+const testAccPromptCustomTextUpdate = `
+
+resource "auth0_prompt_custom_text" "prompt_custom_text" {
+	prompt = "login"
+	language = "en"
+	body = "{\"login\": { \"alertListTitle\": \"Alerts\", \"buttonText\": \"Continue to Login\"}}""
+  }
+  `

--- a/auth0/resource_auth0_prompt_custom_text_test.go
+++ b/auth0/resource_auth0_prompt_custom_text_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestAccPromptCustomText(t *testing.T) {
-
 	resource.Test(t, resource.TestCase{
 		Providers: map[string]terraform.ResourceProvider{
 			"auth0": Provider(),
@@ -19,7 +18,11 @@ func TestAccPromptCustomText(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "prompt", "login"),
 					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "language", "en"),
-					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "body", "{\n    \"login\": {\n        \"alertListTitle\": \"Alerts\",\n        \"buttonText\": \"Continue\",\n        \"emailPlaceholder\": \"Email address\"\n    }\n}"),
+					resource.TestCheckResourceAttr(
+						"auth0_prompt_custom_text.prompt_custom_text",
+						"body",
+						"{\n    \"login\": {\n        \"alertListTitle\": \"Alerts\",\n        \"buttonText\": \"Continue\",\n        \"emailPlaceholder\": \"Email address\"\n    }\n}",
+					),
 				),
 			},
 			{
@@ -27,7 +30,11 @@ func TestAccPromptCustomText(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "prompt", "login"),
 					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "language", "en"),
-					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "body", "{\n    \"login\": {\n        \"alertListTitle\": \"Alerts\",\n        \"buttonText\": \"Continue\",\n        \"emailPlaceholder\": \"Email address\"\n    }\n}"),
+					resource.TestCheckResourceAttr(
+						"auth0_prompt_custom_text.prompt_custom_text",
+						"body",
+						"{\n    \"login\": {\n        \"alertListTitle\": \"Alerts\",\n        \"buttonText\": \"Proceed\",\n        \"emailPlaceholder\": \"Email Address\"\n    }\n}",
+					),
 				),
 			},
 		},
@@ -35,33 +42,33 @@ func TestAccPromptCustomText(t *testing.T) {
 }
 
 const testAccPromptCustomTextCreate = `
-
 resource "auth0_prompt_custom_text" "prompt_custom_text" {
   prompt = "login"
   language = "en"
-  body = <<EOF
-{
-"login": {
-	"alertListTitle": "Alerts",
-	"buttonText": "Continue",
-	"emailPlaceholder": "Email address"}
-}
-EOF
+  body = jsonencode(
+    {
+      "login" : {
+        "alertListTitle" : "Alerts",
+        "buttonText" : "Continue",
+        "emailPlaceholder" : "Email address"
+      }
+    }
+  )
 }
 `
 
 const testAccPromptCustomTextUpdate = `
-
 resource "auth0_prompt_custom_text" "prompt_custom_text" {
   prompt = "login"
   language = "en"
-  body = <<EOF
-{
-"login": {
-	"alertListTitle": "Alerts",
-	"buttonText": "Continue",
-	"emailPlaceholder": "Email address"}
+  body = jsonencode(
+    {
+      "login" : {
+        "alertListTitle" : "Alerts",
+        "buttonText" : "Proceed",
+        "emailPlaceholder" : "Email Address"
+      }
+    }
+  )
 }
-EOF
-}
-  `
+`

--- a/auth0/resource_auth0_prompt_custom_text_test.go
+++ b/auth0/resource_auth0_prompt_custom_text_test.go
@@ -18,16 +18,16 @@ func TestAccPromptCustomText(t *testing.T) {
 				Config: testAccPromptCustomTextCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "prompt", "login"),
-					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "login", "en"),
-					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "body", "{\"login\": { \"alertListTitle\": \"Alerts\", \"buttonText\": \"Continue\"}}"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "language", "en"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "body", "{\n    \"login\": {\n        \"alertListTitle\": \"Alerts\",\n        \"buttonText\": \"Continue\",\n        \"emailPlaceholder\": \"Email address\"\n    }\n}"),
 				),
 			},
 			{
 				Config: testAccPromptCustomTextUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "prompt", "login"),
-					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "login", "en"),
-					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "body", "{\"login\": { \"alertListTitle\": \"Alerts\", \"buttonText\": \"Continue to Login\"}}"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "language", "en"),
+					resource.TestCheckResourceAttr("auth0_prompt_custom_text.prompt_custom_text", "body", "{\n    \"login\": {\n        \"alertListTitle\": \"Alerts\",\n        \"buttonText\": \"Continue\",\n        \"emailPlaceholder\": \"Email address\"\n    }\n}"),
 				),
 			},
 		},
@@ -39,15 +39,29 @@ const testAccPromptCustomTextCreate = `
 resource "auth0_prompt_custom_text" "prompt_custom_text" {
   prompt = "login"
   language = "en"
-  body = "{\"login\": { \"alertListTitle\": \"Alerts\", \"buttonText\": \"Continue\"}}""
+  body = <<EOF
+{
+"login": {
+	"alertListTitle": "Alerts",
+	"buttonText": "Continue",
+	"emailPlaceholder": "Email address"}
+}
+EOF
 }
 `
 
 const testAccPromptCustomTextUpdate = `
 
 resource "auth0_prompt_custom_text" "prompt_custom_text" {
-	prompt = "login"
-	language = "en"
-	body = "{\"login\": { \"alertListTitle\": \"Alerts\", \"buttonText\": \"Continue to Login\"}}""
-  }
+  prompt = "login"
+  language = "en"
+  body = <<EOF
+{
+"login": {
+	"alertListTitle": "Alerts",
+	"buttonText": "Continue",
+	"emailPlaceholder": "Email address"}
+}
+EOF
+}
   `

--- a/docs/resources/prompt_custom_text.md
+++ b/docs/resources/prompt_custom_text.md
@@ -1,0 +1,60 @@
+---
+layout: "auth0"
+page_title: "Auth0: auth0_prompt_custom_text"
+description: |-
+    With this resource, you can manage your Auth0 prompts custom text.
+---
+
+# auth0_prompt_custom_text
+
+With this resource, you can manage your Auth0 prompts custom text. You can read more about custom texts [here](https://auth0.com/docs/customize/universal-login-pages/customize-login-text-prompts).
+
+## Example Usage
+
+```hcl
+resource "auth0_prompt_custom_text" "example" {
+  prompt   = "login"
+  language = "en"
+  body     = <<EOT
+  {
+  "login": {
+    "alertListTitle": "Alerts",
+    "buttonText": "Continue",
+    "description": "Login to",
+    "editEmailText": "Edit",
+    "emailPlaceholder": "Email address",
+    "federatedConnectionButtonText": "Continue with ${connectionName}",
+    "footerLinkText": "Sign up",
+    "footerText": "Don't have an account?",
+    "forgotPasswordText": "Forgot password?",
+    "invitationDescription": "Log in to accept ${inviterName}'s invitation to join ${companyName} on ${clientName}.",
+    "invitationTitle": "You've Been Invited!",
+    "logoAltText": "${companyName}",
+    "pageTitle": "Log in | ${clientName}",
+    "passwordPlaceholder": "Password",
+    "separatorText": "Or",
+    "signupActionLinkText": "${footerLinkText}",
+    "signupActionText": "${footerText}",
+    "title": "Welcome",
+    "usernamePlaceholder": "Username or email address"
+  }
+}
+  EOT
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `prompt` - (Required) The term `prompt` is used to refer to a specific step in the login flow. Options include `login`, `login-id`, `login-password`, `login-email-verification`, `signup`, `signup-id`, `signup-password`, `reset-password`, `consent`, `mfa-push`, `mfa-otp`, `mfa-voice`, `mfa-phone`, `mfa-webauthn`, `mfa-sms`, `mfa-email`, `mfa-recovery-code`, `mfa`, `status`, `device-flow`, `email-verification`, `email-otp-challenge`, `organizations`, `invitation`, `common`
+* `language` - (Required) Language of the custom text. Options include `ar`, `bg`, `bs`, `cs`, `da`, `de`, `el`, `en`, `es`, `et`, `fi`, `fr`, `fr-CA`, `fr-FR`, `he`, `hi`, `hr`, `hu`, `id`, `is`, `it`, `ja`, `ko`, `lt`, `lv`, `nb`, `nl`, `pl`, `pt`, `pt-BR`, `pt-PT`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`,
+* `body` - (Required) JSON containing the custom texts. You can check the options for each prompt [here](https://auth0.com/docs/customize/universal-login-pages/customize-login-text-prompts#prompt-values)
+
+## Import
+
+auth0_prompt_custom_text can be imported using the import command and specifing the prompt and language separaged by *:* , e.g.
+
+```terminal
+terraform import auth0_prompt_custom_text.example login:en
+```

--- a/docs/resources/prompt_custom_text.md
+++ b/docs/resources/prompt_custom_text.md
@@ -2,12 +2,13 @@
 layout: "auth0"
 page_title: "Auth0: auth0_prompt_custom_text"
 description: |-
-    With this resource, you can manage your Auth0 prompts custom text.
+    With this resource, you can manage custom texts on your Auth0 prompts.
 ---
 
 # auth0_prompt_custom_text
 
-With this resource, you can manage your Auth0 prompts custom text. You can read more about custom texts [here](https://auth0.com/docs/customize/universal-login-pages/customize-login-text-prompts).
+With this resource, you can manage custom text on your Auth0 prompts. You can read more about custom texts
+[here](https://auth0.com/docs/customize/universal-login-pages/customize-login-text-prompts).
 
 ## Example Usage
 
@@ -15,31 +16,31 @@ With this resource, you can manage your Auth0 prompts custom text. You can read 
 resource "auth0_prompt_custom_text" "example" {
   prompt   = "login"
   language = "en"
-  body     = <<EOT
-  {
-  "login": {
-    "alertListTitle": "Alerts",
-    "buttonText": "Continue",
-    "description": "Login to",
-    "editEmailText": "Edit",
-    "emailPlaceholder": "Email address",
-    "federatedConnectionButtonText": "Continue with ${connectionName}",
-    "footerLinkText": "Sign up",
-    "footerText": "Don't have an account?",
-    "forgotPasswordText": "Forgot password?",
-    "invitationDescription": "Log in to accept ${inviterName}'s invitation to join ${companyName} on ${clientName}.",
-    "invitationTitle": "You've Been Invited!",
-    "logoAltText": "${companyName}",
-    "pageTitle": "Log in | ${clientName}",
-    "passwordPlaceholder": "Password",
-    "separatorText": "Or",
-    "signupActionLinkText": "${footerLinkText}",
-    "signupActionText": "${footerText}",
-    "title": "Welcome",
-    "usernamePlaceholder": "Username or email address"
-  }
-}
-  EOT
+  body = jsonencode(
+    {
+      "login" : {
+        "alertListTitle" : "Alerts",
+        "buttonText" : "Continue",
+        "description" : "Login to",
+        "editEmailText" : "Edit",
+        "emailPlaceholder" : "Email address",
+        "federatedConnectionButtonText" : "Continue with ${connectionName}",
+        "footerLinkText" : "Sign up",
+        "footerText" : "Don't have an account?",
+        "forgotPasswordText" : "Forgot password?",
+        "invitationDescription" : "Log in to accept ${inviterName}'s invitation to join ${companyName} on ${clientName}.",
+        "invitationTitle" : "You've Been Invited!",
+        "logoAltText" : "${companyName}",
+        "pageTitle" : "Log in | ${clientName}",
+        "passwordPlaceholder" : "Password",
+        "separatorText" : "Or",
+        "signupActionLinkText" : "${footerLinkText}",
+        "signupActionText" : "${footerText}",
+        "title" : "Welcome",
+        "usernamePlaceholder" : "Username or email address"
+      }
+    }
+  )
 }
 ```
 
@@ -48,12 +49,13 @@ resource "auth0_prompt_custom_text" "example" {
 The following arguments are supported:
 
 * `prompt` - (Required) The term `prompt` is used to refer to a specific step in the login flow. Options include `login`, `login-id`, `login-password`, `login-email-verification`, `signup`, `signup-id`, `signup-password`, `reset-password`, `consent`, `mfa-push`, `mfa-otp`, `mfa-voice`, `mfa-phone`, `mfa-webauthn`, `mfa-sms`, `mfa-email`, `mfa-recovery-code`, `mfa`, `status`, `device-flow`, `email-verification`, `email-otp-challenge`, `organizations`, `invitation`, `common`
-* `language` - (Required) Language of the custom text. Options include `ar`, `bg`, `bs`, `cs`, `da`, `de`, `el`, `en`, `es`, `et`, `fi`, `fr`, `fr-CA`, `fr-FR`, `he`, `hi`, `hr`, `hu`, `id`, `is`, `it`, `ja`, `ko`, `lt`, `lv`, `nb`, `nl`, `pl`, `pt`, `pt-BR`, `pt-PT`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`,
+* `language` - (Required) Language of the custom text. Options include `ar`, `bg`, `bs`, `cs`, `da`, `de`, `el`, `en`, `es`, `et`, `fi`, `fr`, `fr-CA`, `fr-FR`, `he`, `hi`, `hr`, `hu`, `id`, `is`, `it`, `ja`, `ko`, `lt`, `lv`, `nb`, `nl`, `pl`, `pt`, `pt-BR`, `pt-PT`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `th`, `tr`, `uk`, `vi`, `zh-CN`, `zh-TW`
 * `body` - (Required) JSON containing the custom texts. You can check the options for each prompt [here](https://auth0.com/docs/customize/universal-login-pages/customize-login-text-prompts#prompt-values)
 
 ## Import
 
-auth0_prompt_custom_text can be imported using the import command and specifing the prompt and language separaged by *:* , e.g.
+auth0_prompt_custom_text can be imported using the import command and specifying the prompt and language separated
+by *:* , e.g.
 
 ```terminal
 terraform import auth0_prompt_custom_text.example login:en


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Introduces `auth0_prompt_custom_text`


#### Acceptance Test Output
<details>
  <summary>Click to expand test output</summary>
  
```
$ make testacc TESTS=TestAccPromptCustomText
==> Checking that code complies with gofmt requirements...
?       github.com/alexkappa/terraform-provider-auth0   [no test files]
=== RUN   TestAccPromptCustomText
--- PASS: TestAccPromptCustomText (4.68s)
PASS
coverage: 5.0% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0     7.574s  coverage: 5.0% of statements
?       github.com/alexkappa/terraform-provider-auth0/auth0/internal/debug      [no test files]
?       github.com/alexkappa/terraform-provider-auth0/auth0/internal/digitalocean       [no test files]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0/internal/hash       0.390s  coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0/internal/random     0.424s  coverage: 0.0% of statements [no tests to run]
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok      github.com/alexkappa/terraform-provider-auth0/auth0/internal/validation 0.610s  coverage: 0.0% of statements [no tests to run]
?       github.com/alexkappa/terraform-provider-auth0/version   [no test files]
```
</details>

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->