### PR TITLE
Add `ShowAsButton` option

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -611,6 +611,11 @@ var connectionSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Description: "Defines the realms for which the connection will be used (i.e., email domains). If not specified, the connection name is added as the realm",
 	},
+	"show_as_button": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Display connection as a button",
+	},
 }
 
 func connectionSchemaV0() *schema.Resource {
@@ -734,6 +739,7 @@ func readConnection(d *schema.ResourceData, m interface{}) error {
 	d.Set("options", flattenConnectionOptions(d, c.Options))
 	d.Set("enabled_clients", c.EnabledClients)
 	d.Set("realms", c.Realms)
+	d.Set("show_as_button", c.ShowAsButton)
 	return nil
 }
 

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -300,6 +300,7 @@ func expandConnection(d ResourceData) *management.Connection {
 		IsDomainConnection: Bool(d, "is_domain_connection"),
 		EnabledClients:     Set(d, "enabled_clients").List(),
 		Realms:             Slice(d, "realms", IsNewResource(), HasChange()),
+		ShowAsButton:       Bool(d, "show_as_button"),
 	}
 
 	s := d.Get("strategy").(string)

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -51,6 +51,7 @@ Arguments accepted by this resource include:
 * `options` - (Optional) Configuration settings for connection options. For details, see [Options](#options).
 * `enabled_clients` - (Optional) IDs of the clients for which the connection is enabled. If not specified, no clients are enabled.
 * `realms` - (Optional) Defines the realms for which the connection will be used (i.e., email domains). If not specified, the connection name is added as the realm.
+* `show_as_button` - (Optional) Display connection as a button.
 
 ### Options
 


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

* Add a new `show_as_button` option to be able to show a connection as a button (depends on https://github.com/go-auth0/auth0/pull/257).

Fixes #493.

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccXXX
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->