### PR TITLE
DX-CDT-22: Data source helper functions

### DIFF
--- a/auth0/data_source_helpers.go
+++ b/auth0/data_source_helpers.go
@@ -1,0 +1,73 @@
+package auth0
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// datasourceSchemaFromResourceSchema is a recursive func that
+// converts an existing Resource schema to a Datasource schema.
+// All schema elements are copied, but certain attributes are ignored or changed:
+// - all attributes have Computed = true
+// - all attributes have ForceNew, Required = false
+// - Validation funcs and attributes (e.g. MaxItems) are not copied
+func datasourceSchemaFromResourceSchema(rs map[string]*schema.Schema) map[string]*schema.Schema {
+	ds := make(map[string]*schema.Schema, len(rs))
+	for k, v := range rs {
+		dv := &schema.Schema{
+			Computed:    true,
+			ForceNew:    false,
+			Required:    false,
+			Description: v.Description,
+			Type:        v.Type,
+		}
+
+		switch v.Type {
+		case schema.TypeSet:
+			dv.Set = v.Set
+			fallthrough
+		case schema.TypeList:
+			// List & Set types are generally used for 2 cases:
+			// - a list/set of simple primitive values (e.g. list of strings)
+			// - a sub resource
+			if elem, ok := v.Elem.(*schema.Resource); ok {
+				// handle the case where the Element is a sub-resource
+				dv.Elem = &schema.Resource{
+					Schema: datasourceSchemaFromResourceSchema(elem.Schema),
+				}
+			} else {
+				// handle simple primitive case
+				dv.Elem = v.Elem
+			}
+
+		default:
+			// Elem of all other types are copied as-is
+			dv.Elem = v.Elem
+
+		}
+		ds[k] = dv
+
+	}
+	return ds
+}
+
+// fixDatasourceSchemaFlags is a convenience func that toggles the Computed,
+// Optional + Required flags on a schema element. This is useful when the schema
+// has been generated (using `datasourceSchemaFromResourceSchema` above for
+// example) and therefore the attribute flags were not set appropriately when
+// first added to the schema definition. Currently only supports top-level
+// schema elements.
+func fixDatasourceSchemaFlags(schema map[string]*schema.Schema, required bool, keys ...string) {
+	for _, v := range keys {
+		schema[v].Computed = false
+		schema[v].Optional = !required
+		schema[v].Required = required
+	}
+}
+
+func addRequiredFieldsToSchema(schema map[string]*schema.Schema, keys ...string) {
+	fixDatasourceSchemaFlags(schema, true, keys...)
+}
+
+func addOptionalFieldsToSchema(schema map[string]*schema.Schema, keys ...string) {
+	fixDatasourceSchemaFlags(schema, false, keys...)
+}

--- a/auth0/data_source_helpers_test.go
+++ b/auth0/data_source_helpers_test.go
@@ -1,0 +1,77 @@
+package auth0
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var newMockResourceSchema = map[string]*schema.Schema{
+	"string_prop": {
+		Type:        schema.TypeString,
+		Description: "Some string property passed into mock schema",
+		Required:    true,
+	},
+	"map_prop": {
+		Type:     schema.TypeMap,
+		Optional: true,
+	},
+	"bool_prop": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Computed: false,
+	},
+	"list_prop": {
+		Type:     schema.TypeList,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+		Optional: true,
+	},
+	"float_prop": {
+		Type:     schema.TypeFloat,
+		Optional: true,
+		Computed: false,
+	},
+	"set_prop": {
+		Type:        schema.TypeSet,
+		Optional:    true,
+		Description: "Some set property passed into mock schema",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"set_prop_child": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	},
+}
+
+func TestDatasourceSchemaFromResourceSchema(t *testing.T) {
+	dsSchema := datasourceSchemaFromResourceSchema(newMockResourceSchema)
+
+	if len(dsSchema) != len(newMockResourceSchema) {
+		t.Errorf("Unexpected number of properties in schema: got %v want %v", len(dsSchema), len(newMockResourceSchema))
+	}
+
+	for k, v := range dsSchema {
+		if v.Optional == true {
+			t.Errorf("Expected %v schema property to be required", k)
+		}
+
+		if v.Computed == false {
+			t.Errorf("Expected %v schema property to be computed", k)
+		}
+
+		if v.Description != newMockResourceSchema[k].Description {
+			t.Errorf("Description not being passed correctly, got %v want %v", v.Description, newMockResourceSchema[k].Description)
+		}
+
+		if v.Type != newMockResourceSchema[k].Type {
+			t.Errorf("Unexpected number of properties in schema: got %v want %v", len(dsSchema), len(newMockResourceSchema))
+		}
+
+		if (k == "list_prop" || k == "set_prop") && v.Elem == nil {
+			t.Errorf("Non-nil elements passed into list or set type properties")
+		}
+	}
+}


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

Reintroduces data source helpers that were introduced in PR #363 that was quickly reverted due to some type of regression . Discussion around data sources has gotten a lot of activity that has largely been unresolved (see #281, #279 and #429) so this PR will be the first of several PRs that will implement data sources over the coming weeks.

Credit to @yinzara for originally writing the function. My only contribution here is the addition of a basic test.

#### Acceptance Test Output

```
$ make testacc TESTS=TestAccXXX

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->