### PR TITLE
DXCDT-21: Global client data source

### DIFF
--- a/auth0/data_source_auth0_client.go
+++ b/auth0/data_source_auth0_client.go
@@ -10,15 +10,17 @@ import (
 )
 
 func newDataClient() *schema.Resource {
-	clientSchema := datasourceSchemaFromResourceSchema(newClient().Schema)
-	delete(clientSchema, "client_secret_rotation_trigger")
-
-	addOptionalFieldsToSchema(clientSchema, "name", "client_id")
-
 	return &schema.Resource{
 		Read:   readDataClient,
-		Schema: clientSchema,
+		Schema: newClientSchema(),
 	}
+}
+
+func newClientSchema() map[string]*schema.Schema {
+	clientSchema := datasourceSchemaFromResourceSchema(newClient().Schema)
+	delete(clientSchema, "client_secret_rotation_trigger")
+	addOptionalFieldsToSchema(clientSchema, "name", "client_id")
+	return clientSchema
 }
 
 func readDataClient(d *schema.ResourceData, m interface{}) error {

--- a/auth0/data_source_auth0_global_client.go
+++ b/auth0/data_source_auth0_global_client.go
@@ -1,0 +1,19 @@
+package auth0
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func newDataGlobalClient() *schema.Resource {
+	return &schema.Resource{
+		Read:   readDataGlobalClient,
+		Schema: newClientSchema(),
+	}
+}
+
+func readDataGlobalClient(d *schema.ResourceData, m interface{}) error {
+	if err := readGlobalClientId(d, m); err != nil {
+		return err
+	}
+	return readClient(d, m)
+}

--- a/auth0/data_source_auth0_global_client_test.go
+++ b/auth0/data_source_auth0_global_client_test.go
@@ -1,0 +1,35 @@
+package auth0
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+const testAccDataGlobalClientConfig = `
+%v
+data auth0_global_client global {
+}
+`
+
+func TestAccDataGlobalClient(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccDataGlobalClientConfig, testAccGlobalClientConfigWithCustomLogin),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.auth0_global_client.global", "custom_login_page", "<html>TEST123</html>"),
+					resource.TestCheckResourceAttr("data.auth0_global_client.global", "custom_login_page_on", "true"),
+					resource.TestCheckResourceAttrSet("data.auth0_global_client.global", "client_id"),
+					resource.TestCheckResourceAttr("data.auth0_global_client.global", "app_type", ""),
+					resource.TestCheckResourceAttr("data.auth0_global_client.global", "name", "All Applications"),
+				),
+			},
+		},
+	})
+}

--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -69,7 +69,8 @@ func Provider() *schema.Provider {
 			"auth0_trigger_binding":            newTriggerBinding(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"auth0_client": newDataClient(),
+			"auth0_client":        newDataClient(),
+			"auth0_global_client": newDataGlobalClient(),
 		},
 	}
 

--- a/docs/datasources/global_client.md
+++ b/docs/datasources/global_client.md
@@ -1,0 +1,33 @@
+---
+layout: "auth0"
+page_title: "Data Source: auth0_global_client"
+description: |-
+Retrieves a tenant's global Auth0 Application client
+---
+
+# Data Source: auth0_global_client
+
+Retrieves a tenant's global Auth0 Application client
+
+## Example Usage
+
+```hcl
+data "auth0_global_client" "global" {
+}
+```
+
+## Argument Reference
+
+No arguments accepted.
+
+## Attribute Reference
+
+* `client_id` - String. ID of the client.
+* `client_secret`<sup>[1](#client-keys)</sup> - String. Secret for the client; keep this private.
+* `custom_login_page_on` - Boolean. Indicates whether or not a custom login page is to be used.
+* `custom_login_page` - String. Content of the custom login page.
+* `client_metadata` - (Optional) Map(String)
+
+### Client Keys
+
+To access the `client_secret` attribute you need to add the `read:client_keys` scope to the Terraform client. Otherwise, the attribute will contain an empty string.


### PR DESCRIPTION
<!--- 

**IMPORTANT:** Please submit pull requests to [alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0). This helps maintainers organize work more efficiently.

See what makes a good Pull Request at : https://github.com/alexkappa/terraform-provider-auth0/blob/master/.github/CONTRIBUTING.md#pull-requests 

--->
### Proposed Changes

Adding global client data source. Similarly to #511 , this PR heavily references @yinzara 's #363. 

**Still in draft** as I better understand the use case and expected attributes; I've pointed out some inconsistencies below.


#### Acceptance Test Output

```
$ make testacc TESTS=TestAccXXX

=== RUN   TestAccDataGlobalClient
--- PASS: TestAccDataGlobalClient (3.95s)
PASS
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->